### PR TITLE
Parse custom packages correctly

### DIFF
--- a/bdsim/run_sim.py
+++ b/bdsim/run_sim.py
@@ -1004,9 +1004,9 @@ class BDSim:
         packages = ["bdsim", "roboticstoolbox", "machinevisiontoolbox"]
         env = os.getenv("BDSIMPATH")
         if env is not None:
-            packages.append(env.split)
+            packages += env.split(":")
         if self.packages is not None:
-            packages.append(self.packages.split(":"))
+            packages += self.packages.split(":")
 
         blocks = {}
         moduledicts = {}


### PR DESCRIPTION
Fixes incorrect parsing of packages kwarg.

For example:
```python
# This now works as well as BDSIM_PATH
bdsim.BDSim(packages="bdsim_realtime:another_package")
```