### PR TITLE
fixed shapes before Ax+Bu calc

### DIFF
--- a/bdsim/blocks/transfers.py
+++ b/bdsim/blocks/transfers.py
@@ -295,10 +295,11 @@ class LTI_SS(TransferBlock):
         return list(self.C @ x)
 
     def deriv(self, t, u, x):
-        #Make sure the input arrays are (N,1) so no problems with broadcasting
-        x = x.reshape(-1,1)
-        u = np.array(u).reshape(-1,1)
-        xd = self.A @ x + self.B @ np.array(u)
+        # Reshape u and x to (N,1), i.e. column vectors, so
+        # no problems with broadcasting between A@x and B@u
+        x = x.reshape(-1, 1)
+        u = np.array(u).reshape(-1, 1)
+        xd = self.A @ x + self.B @ u
         return xd.flatten()
 
 

--- a/bdsim/blocks/transfers.py
+++ b/bdsim/blocks/transfers.py
@@ -295,6 +295,9 @@ class LTI_SS(TransferBlock):
         return list(self.C @ x)
 
     def deriv(self, t, u, x):
+        #Make sure the input arrays are (N,1) so no problems with broadcasting
+        x = x.reshape(-1,1)
+        u = np.array(u).reshape(-1,1)
         xd = self.A @ x + self.B @ np.array(u)
         return xd.flatten()
 


### PR DESCRIPTION
This is a fix for issue20 - it forces the shapes of the inputs to xdot = Ax+Bu calculation in LTI_SS to be (N,1) so that inputs such as [1.0] and [array([1.0])] both work correctly.

make test produces
 115 passed, 1 skipped, 11 warnings in 0.51s