### PR TITLE
Default for PID arg I_band should be None, not 0

### DIFF
--- a/bdsim/blocks/transfers.py
+++ b/bdsim/blocks/transfers.py
@@ -602,7 +602,7 @@ class PID(SubsystemBlock):
         I: float = 0.0,
         D_pole=1,
         I_limit=None,
-        I_band=0,
+        I_band=None,
         **blockargs,
     ):
         r"""


### PR DESCRIPTION
Changed default for PID arg I_band to match documentation - do nothing if not provided.  Otherwise the default is for an I_band=0.0 which means it will never be activated ( abs(error)<I_band for it to be integrating).