### PR TITLE
fix(blocks): Dict block exposes N inputs and returns list

### DIFF
--- a/src/bdsim/blocks/connections.py
+++ b/src/bdsim/blocks/connections.py
@@ -133,7 +133,7 @@ class Dict(FunctionBlock):
     :seealso: :class:`Item` :class:`Mux`
     """
 
-    nin = 1  # type: ignore[assignment]
+    nin: int = -1
     nout = 1  # type: ignore[assignment]
 
     def __init__(self, keys: list[str], **blockargs: Any) -> None:
@@ -144,11 +144,11 @@ class Dict(FunctionBlock):
         :type blockargs: dict
         """
 
-        super().__init__(**blockargs)
+        super().__init__(nin=len(keys), **blockargs)
         self.keys: list[str] = keys
 
-    def output(self, t: float, inputs: list[Any], x: Any) -> Any:
-        return {key: inputs[i] for i, key in enumerate(self.keys)}
+    def output(self, t: float, inputs: list[Any], x: Any) -> list[Any]:
+        return [{key: inputs[i] for i, key in enumerate(self.keys)}]
 
 
 # ------------------------------------------------------------------------ #

--- a/tests/blocks/test_blocks_connections.py
+++ b/tests/blocks/test_blocks_connections.py
@@ -33,6 +33,21 @@ class ConnectionsTest(unittest.TestCase):
         sig = {"sig1": 1, "sig2": 2, "sig3": 3}
         self.assertEqual(block.test_output(sig)[0], 2)
 
+    def test_dict_multi_input_nin(self):
+        """DICT with N keys must expose N inputs (regression: nin wasn't
+        propagated from len(keys), so wiring more than 1 input failed)."""
+        block = Dict(["a", "b", "c"])
+        self.assertEqual(block.nin, 3)
+        out = block.test_output(1, 2, 3)
+        self.assertEqual(out[0], {"a": 1, "b": 2, "c": 3})
+
+    def test_dict_output_is_list_wrapped(self):
+        """DICT.output() must return a single-element list per the Block
+        contract (regression: it returned a bare dict)."""
+        block = Dict(["x"])
+        out = block.test_output(5)
+        self.assertEqual(out[0], {"x": 5})
+
     # subsystems are tested by test_blockdiagram
 
 


### PR DESCRIPTION
## Summary

Two bugs in `bdsim.blocks.connections.Dict`. Together they make
`bd.DICT([...])` unusable for any keys list longer than 1 (and broken
even then, since the output isn't list-wrapped).

## Bug 1 — `nin` not propagated

```python
class Dict(FunctionBlock):
    nin = 1  # ← class attribute
    def __init__(self, keys: list[str], **blockargs: Any) -> None:
        super().__init__(**blockargs)   # ← nin=len(keys) missing
```

`bd.DICT(["a", "b", "c"])` exposes only input 0. Wiring to
`dict_blk[1]` or `dict_blk[2]` fails at compile with:

```
error connecting wire ... --> .../dict.0[1]: list index out of range
```

## Bug 2 — `output()` returns bare dict

```python
def output(self, t: float, inputs: list[Any], x: Any) -> Any:
    return {key: inputs[i] for i, key in enumerate(self.keys)}
```

bdsim expects `output()` to return `list[Any]` (one entry per output
port). Even after fixing bug 1, running a diagram with a Dict block
fails:

```
AssertionError: block Block.function(... type=dict, nout=1) output
... must be a list: <class 'dict'>
```

## Fix

```python
nin: int = -1
...
super().__init__(nin=len(keys), **blockargs)
...
def output(self, t: float, inputs: list[Any], x: Any) -> list[Any]:
    return [{key: inputs[i] for i, key in enumerate(self.keys)}]
```

Mirrors the variable-input pattern in `Mux` (~30 lines below in the
same file), which is correct: `nin: int = -1` + `super().__init__(
nin=nin, ...)` + list-wrapped output.

## History

The original `class Dict` introduced in `5b2bc33` (May 2021) was
actually an Item-extractor (1 dict input → 1 value out). A later
refactor (`f7ba8b4`) split `Item` into its own class and rewrote
`Dict.output()` to do the correct N→dict pack, but kept the
`nin = 1` from the original Item-as-Dict implementation and forgot
the list-wrap.

## Base

This PR is against `12b26c2` ("add the tagline") rather than current
`main` HEAD because of #34 (current main can't `import bdsim` — a
missing `graphics_block.py` from a recent move). The fix is in
`connections.py` and is orthogonal to the graphics breakage, so it
should rebase cleanly onto fixed-main.

## Test plan

- [x] `bd.DICT(["a", "b", "c"])` reports `nin == 3`.
- [x] Wire three CONSTANT blocks to the three slots; diagram compiles
      and runs.
- [x] Output dict has the three expected keys with the wired values.

No tests added to the bdsim test suite — leaving that to a broader
testing pass.