### PR TITLE
Fix gen_index.py f-string syntax for Python 3.10

### DIFF
--- a/docs/lite/gen_index.py
+++ b/docs/lite/gen_index.py
@@ -25,6 +25,5 @@ for whl in sorted(pypi.glob("*.whl")):
     index.setdefault(name, []).append(entry)
 
 (pypi / "all.json").write_text(json.dumps(index, indent=2) + "\n")
-print(
-    f"wrote pypi/all.json ({', '.join(f'{k} {v[0]['version']}' for k, v in index.items())})"
-)
+summary = ", ".join(f"{k} {v[0]['version']}" for k, v in index.items())
+print(f"wrote pypi/all.json ({summary})")


### PR DESCRIPTION
## Summary
- `docs/lite/gen_index.py` nested an f-string inside another f-string's replacement field reusing the same quote character — only valid from Python 3.12 (PEP 701).
- The "Docs and Pages" workflow runs on Python 3.10, so `Build local bdsim wheel for JupyterLite` hit a `SyntaxError` and failed before Sphinx or JupyterLite ever ran.
- Pulled the join into a separate `summary` variable so there's no nested f-string.

## Test plan
- [x] `ast.parse()` of the fixed file succeeds under Python 3.10.15 (`RVC3_10` conda env) and 3.12.8
- [ ] CI's "Docs and Pages" workflow passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)