### PR TITLE
Ignore scratch UNTRACKED/ dir and local sibling-repo symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,10 @@ bdweb/frontend/.output/
 bdweb/frontend/.vercel/
 bdweb/frontend/.netlify/
 bdweb/frontend/.wrangler/
+
+# scratch/working files not meant for the repo
+/UNTRACKED
+
+# local symlinks to sibling repos
+/wiki
+/examples/RVC3


### PR DESCRIPTION
## Summary
- Working-tree scratch files (notes, one-off scripts, saved diagrams) had piled up untracked at various paths across the repo.
- Moved them into `UNTRACKED/` (mirroring their original relative paths) and added it to `.gitignore`.
- Also ignored the `wiki` and `examples/RVC3` symlinks, which point at sibling repos outside this checkout and were showing up as untracked.

## Test plan
- [x] `git status` is clean aside from `.gitignore` itself
- [x] No tracked files were touched, only previously-untracked ones moved

🤖 Generated with [Claude Code](https://claude.com/claude-code)