### PR TITLE
Fix broken logo/badge URLs and README markdown fences

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 
 <div align="center">
-  <img src="https://raw.githubusercontent.com/petercorke/bdsim/master/figs/BDSimLogo_NoBackgnd@2x.png" width="500" alt="bdsim logo">
+  <img src="https://raw.githubusercontent.com/petercorke/bdsim/main/docs/figs/bdsim_logo.png" width="500" alt="bdsim logo">
   <br>
   <strong>A Pythonic block-diagram environment for the simulation and analysis of dynamic systems.</strong>
   <br><br>
@@ -20,7 +20,7 @@
 
 
 [![JupyterLite](https://img.shields.io/badge/Try_it_Now-JupyterLite-orange?style=for-the-badge&logo=jupyter)](https://petercorke.github.io/bdsim/lite/lab?path=index.ipynb)
-  [![PyPI version](https://img.shields.io/pypi/v/machinevision-toolbox-python?style=for-the-badge&color=blue)](https://pypi.org/project/bdsim/)
+  [![PyPI version](https://img.shields.io/pypi/v/bdsim?style=for-the-badge&color=blue)](https://pypi.org/project/bdsim/)
   [![Documentation](https://img.shields.io/badge/Docs-View_Online-blue?style=for-the-badge)](https://petercorke.github.io/bdsim/)
 
   <p>
@@ -66,9 +66,11 @@ You can install `bdsim` directly from PyPI:
 
 ```bash
 pip install bdsim
+```
+
 To include the graphical editor (bdedit) and its dependencies:
 
-Bash
+```bash
 pip install bdsim[editor]
 ```
 
@@ -81,7 +83,6 @@ Or skip setup and run the [browser-based JupyterLite examples](https://petercork
 The power of bdsim lies in its conciseness. The step response of a simple first-order system can be defined and simulated in just a few lines of code:
 
 ```python
-Python
 import bdsim
 
 sim = bdsim.BDSim()

--- a/docs/notebooks/advanced-topics.ipynb
+++ b/docs/notebooks/advanced-topics.ipynb
@@ -4,16 +4,7 @@
    "cell_type": "markdown",
    "id": "022176cd",
    "metadata": {},
-   "source": [
-    "<table>\n",
-    "  <tr>\n",
-    "    <td><div align=\"left\"><font size=\"30\">Advanced topics</font></div></td>\n",
-    "    <td><img src=\"https://raw.githubusercontent.com/petercorke/bdsim/master/figs/BDSimLogo_NoBackgnd%402x.png\" width=\"300\"></td>\n",
-    "  </tr>\n",
-    "</table>\n",
-    "\n",
-    "(c) Peter Corke 2026"
-   ]
+   "source": "<table>\n  <tr>\n    <td><div align=\"left\"><font size=\"30\">Advanced topics</font></div></td>\n    <td><img src=\"https://raw.githubusercontent.com/petercorke/bdsim/main/docs/figs/bdsim_logo.png\" width=\"300\"></td>\n  </tr>\n</table>\n\n(c) Peter Corke 2026"
   },
   {
    "cell_type": "code",

--- a/docs/notebooks/bouncing-ball.ipynb
+++ b/docs/notebooks/bouncing-ball.ipynb
@@ -4,16 +4,7 @@
    "cell_type": "markdown",
    "id": "bfa78a2b",
    "metadata": {},
-   "source": [
-    "<table>\n",
-    "  <tr>\n",
-    "    <td><div align=\"left\"><font size=\"30\">Bouncing ball simulation</font></div></td>\n",
-    "    <td><img src=\"https://raw.githubusercontent.com/petercorke/bdsim/master/figs/BDSimLogo_NoBackgnd%402x.png\" width=\"300\"></td>\n",
-    "  </tr>\n",
-    "</table>\n",
-    "\n",
-    "(c) Peter Corke 2026"
-   ]
+   "source": "<table>\n  <tr>\n    <td><div align=\"left\"><font size=\"30\">Bouncing ball simulation</font></div></td>\n    <td><img src=\"https://raw.githubusercontent.com/petercorke/bdsim/main/docs/figs/bdsim_logo.png\" width=\"300\"></td>\n  </tr>\n</table>\n\n(c) Peter Corke 2026"
   },
   {
    "cell_type": "code",

--- a/docs/notebooks/discrete-time+hybrid.ipynb
+++ b/docs/notebooks/discrete-time+hybrid.ipynb
@@ -4,16 +4,7 @@
    "cell_type": "markdown",
    "id": "022176cd",
    "metadata": {},
-   "source": [
-    "<table>\n",
-    "  <tr>\n",
-    "    <td><div align=\"left\"><font size=\"30\">Discrete-time and hybrid systems</font></div></td>\n",
-    "    <td><img src=\"https://raw.githubusercontent.com/petercorke/bdsim/master/figs/BDSimLogo_NoBackgnd%402x.png\" width=\"300\"></td>\n",
-    "  </tr>\n",
-    "</table>\n",
-    "\n",
-    "(c) Peter Corke 2026"
-   ]
+   "source": "<table>\n  <tr>\n    <td><div align=\"left\"><font size=\"30\">Discrete-time and hybrid systems</font></div></td>\n    <td><img src=\"https://raw.githubusercontent.com/petercorke/bdsim/main/docs/figs/bdsim_logo.png\" width=\"300\"></td>\n  </tr>\n</table>\n\n(c) Peter Corke 2026"
   },
   {
    "cell_type": "code",

--- a/docs/notebooks/getting-started.ipynb
+++ b/docs/notebooks/getting-started.ipynb
@@ -4,16 +4,7 @@
    "cell_type": "markdown",
    "id": "022176cd",
    "metadata": {},
-   "source": [
-    "<table>\n",
-    "  <tr>\n",
-    "    <td><div align=\"left\"><font size=\"30\">Getting started</font></div></td>\n",
-    "    <td><img src=\"https://raw.githubusercontent.com/petercorke/bdsim/master/figs/BDSimLogo_NoBackgnd%402x.png\" width=\"300\"></td>\n",
-    "  </tr>\n",
-    "</table>\n",
-    "\n",
-    "(c) Peter Corke 2026"
-   ]
+   "source": "<table>\n  <tr>\n    <td><div align=\"left\"><font size=\"30\">Getting started</font></div></td>\n    <td><img src=\"https://raw.githubusercontent.com/petercorke/bdsim/main/docs/figs/bdsim_logo.png\" width=\"300\"></td>\n  </tr>\n</table>\n\n(c) Peter Corke 2026"
   },
   {
    "cell_type": "code",

--- a/docs/notebooks/index.ipynb
+++ b/docs/notebooks/index.ipynb
@@ -4,25 +4,7 @@
    "cell_type": "markdown",
    "id": "b6f5f75f",
    "metadata": {},
-   "source": [
-    "<table style=\"border-collapse: collapse; border: none;\">\n",
-    "  <tr>\n",
-    "    <td style=\"border: none; padding: 0 12px 0 0;\"><img src=\"https://raw.githubusercontent.com/petercorke/bdsim/master/figs/BDSimLogo_NoBackgnd%402x.png\" width=\"200\"></td>\n",
-    "    <td style=\"border: none;\"><div align=\"left\"><font size=\"6\">Interactive Browser Tutorials & Demos</font></div></td>\n",
-    "  </tr>\n",
-    "</table>\n",
-    "\n",
-    "\n",
-    "Welcome to the interactive companion for **bdsim**: Block Diagram Simulation for Python. These notebooks run entirely in your browser via **JupyterLite**—no installation, no configuration, just code.\n",
-    "\n",
-    "\n",
-    "| Tutorial | Description |\n",
-    "| :--- | :--- |\n",
-    "| [**Introduction**](./getting-started.ipynb) | 🚀 A quick introduction to the package. |\n",
-    "| [**Discrete & hybrid systems**](./discrete-time+hybrid.ipynb) | ⏱️ Simulating discrete-time and mixed discrete-/continuous-time systems. |\n",
-    "| [**Event-based systems**](./bouncing-ball.ipynb) | 🏀 The classic bouncing ball example. |\n",
-    "| [**Advanced topics**](./advanced-topics.ipynb) | 🎓 Advanced options: options, movies, animation, block loading |\n"
-   ]
+   "source": "<table style=\"border-collapse: collapse; border: none;\">\n  <tr>\n    <td style=\"border: none; padding: 0 12px 0 0;\"><img src=\"https://raw.githubusercontent.com/petercorke/bdsim/main/docs/figs/bdsim_logo.png\" width=\"200\"></td>\n    <td style=\"border: none;\"><div align=\"left\"><font size=\"6\">Interactive Browser Tutorials & Demos</font></div></td>\n  </tr>\n</table>\n\n\nWelcome to the interactive companion for **bdsim**: Block Diagram Simulation for Python. These notebooks run entirely in your browser via **JupyterLite**—no installation, no configuration, just code.\n\n\n| Tutorial | Description |\n| :--- | :--- |\n| [**Introduction**](./getting-started.ipynb) | 🚀 A quick introduction to the package. |\n| [**Discrete & hybrid systems**](./discrete-time+hybrid.ipynb) | ⏱️ Simulating discrete-time and mixed discrete-/continuous-time systems. |\n| [**Event-based systems**](./bouncing-ball.ipynb) | 🏀 The classic bouncing ball example. |\n| [**Advanced topics**](./advanced-topics.ipynb) | 🎓 Advanced options: options, movies, animation, block loading |\n"
   }
  ],
  "metadata": {

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,7 @@ BDSim: Block Diagram Simulation for Python
    <table>
    <tr>
    <td>
-   <img width=350 src="https://github.com/petercorke/bdsim/raw/master/figs/bd1-sketch.png">
+   <img width=350 src="https://github.com/petercorke/bdsim/raw/main/docs/figs/bd1-sketch.png">
    </td>
    <td style="padding-left: 20px;">
    <pre style="font-size:10px;">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,15 @@ license = { file = "LICENSE" }
 
 description = "Simulate dynamic systems expressed in block diagram form using Python"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
     "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]


### PR DESCRIPTION
## Summary
- The May 2026 `src/` layout refactor moved `figs/` -> `docs/figs/` and renamed the logo file (`BDSimLogo_NoBackgnd@2x.png` -> `bdsim_logo.png`), but every hardcoded absolute GitHub URL pointing at the old `master/figs/` location was never updated. Fixes: README's logo, the Sphinx docs front page (`docs/source/index.rst`), and the header image in all five tutorial notebooks.
- README's PyPI version badge queried `machinevision-toolbox-python` instead of `bdsim` (a copy-paste leftover from MVTB's README).
- Two malformed fenced code blocks in the README leaked stray "Bash"/"Python" text into the rendered install instructions.
- `pyproject.toml`'s `requires-python`/`classifiers` narrowed from an untested `>=3.7` to the actually-CI-tested `3.10`-`3.13` — also fixes the blank Python-version badge.

## Test plan
- [x] All 5 edited notebooks still parse as valid JSON
- [x] Clean-checkout build (git worktree) into an isolated throwaway venv, `pip install`, `import bdsim` succeeds, `bdsim.__version__` == `1.3.0`
- [ ] Visual check: README renders correctly on GitHub, Sphinx docs front page image resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)