### PR TITLE
Drop stale 'cleanup' branch from CI workflow triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, cleanup]
+    branches: [main]
   pull_request:
-    branches: [main, cleanup]
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,7 +2,7 @@ name: Docs and Pages
 
 on:
   push:
-    branches: [main, cleanup]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -83,7 +83,7 @@ jobs:
 
   deploy:
     name: deploy to github pages
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/cleanup'
+    if: github.ref == 'refs/heads/main'
     needs: build-site
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Package Artifacts
 
 on:
   push:
-    branches: [main, cleanup]
+    branches: [main]
   release:
     types: [published]
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- The `cleanup` branch was deleted after its work was squash-merged into `main` (2026-05-11). `ci.yml`, `pages.yml`, and `publish.yml` all still listed it as a push trigger / deploy condition.
- Removed `cleanup` from all three; no functional change since the branch no longer exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)