### PR TITLE
ci: add commitlint, enforce Conventional Commit PR titles

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,35 @@
+name: Lint PR title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  commitlint:
+    name: Check PR title (Conventional Commits)
+    runs-on: ubuntu-latest
+    # Dependabot and release-please manage their own titles — skip them.
+    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]' }}
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+            deps
+          requireScope: false
+          # release-please opens PRs like "chore: release 2.0.2" — allow those through
+          ignoreLabels: |
+            autorelease: pending
+            autorelease: tagged


### PR DESCRIPTION
## Summary
First step of building a real release pipeline for bdsim (see the follow-up `release.yml` PR). Currently the only release mechanism is a by-hand `make upload` with no test gate, no OIDC, no changelog automation. A later PR adds `release-please`, which depends on Conventional-Commit-formatted history to categorize changes into `CHANGELOG.md` sections — landing this first and observing it on a few real PRs avoids that later step tripping over inconsistent titles.

Copied verbatim from MVTB (`machinevision-toolbox-python`), which already runs this in production — same allowed types, same dependabot/release-please exemptions.

## Test plan
- [x] Valid YAML
- [ ] Confirm it actually fires and enforces correctly on the next few real PRs before anything depends on it

🤖 Generated with [Claude Code](https://claude.com/claude-code)