### PR TITLE
ci: add OIDC PyPI release workflow, retire manual make upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,85 @@
+# Build and publish to PyPI on GitHub release creation or manual trigger.
+# Uses OIDC trusted publishing — no stored PyPI token required.
+# Pure Python package — a universal wheel suffices; no cibuildwheel needed.
+
+name: Release
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  verify_version:
+    name: Verify tag matches package version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Check version
+        # Skip check on manual workflow_dispatch runs (no release tag exists)
+        if: github.event_name == 'release'
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          echo "Tag version    : $TAG"
+          echo "Package version: $PKG"
+          [ "$TAG" = "$PKG" ] || { echo "ERROR: tag v$TAG does not match pyproject.toml version $PKG"; exit 1; }
+
+  build:
+    name: Build sdist and wheel
+    needs: verify_version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist and wheel
+        run: pipx run build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  smoke_test:
+    name: Smoke-test wheel
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: Install wheel (pulls deps from PyPI)
+        run: pip install --find-links dist bdsim
+
+      - name: Smoke test
+        run: python -c "import bdsim; print('OK', bdsim.__version__)"
+
+  upload_pypi:
+    name: Publish to PyPI
+    needs: [build, smoke_test]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write   # required for OIDC trusted publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip_existing: true

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ help:
 	@echo " make docs - build Sphinx documentation"
 	@echo " make docupdate - upload Sphinx documentation to GitHub pages"
 	@echo " make dist - build dist files"
-	@echo " make upload - upload to PyPI"
 	@echo " make clean - remove dist and docs build files"
 	@echo " make app   - build bdedit.app bundle and register with macOS Launch Services"
 	@echo " make help - this message$(BLACK)"
@@ -38,15 +37,6 @@ dist: .FORCE
 	#$(MAKE) -C src/bdweb build
 	#$(MAKE) test
 	python -m build
-
-upload: .FORCE
-	#$(MAKE) test
-	$(eval VERSION := $(shell grep '^version' pyproject.toml | sed 's/version = "\(.*\)"/\1/'))
-	@echo "Uploading version $(VERSION) to PyPI"
-	twine upload dist/*
-	git tag v$(VERSION)
-	git push origin v$(VERSION)
-	@echo "Tagged and pushed v$(VERSION)"
 
 install:
 	pip install -e .


### PR DESCRIPTION
## Summary
bdsim's only release mechanism until now was a by-hand Makefile target (`make upload`): build locally, `twine upload` with a stored credential, then tag whatever commit happens to be `HEAD` at that moment — no test gate, and the tag step was decoupled from the actual built version (confirmed: tag `v1.2.2` points at a commit whose `pyproject.toml` already said `1.3.0`).

This adds a real pipeline (`release.yml`): verify the release tag matches `pyproject.toml`'s version → build sdist+wheel → install and smoke-test the built wheel → publish via OIDC trusted publishing (no stored PyPI token), gated behind a `pypi` GitHub Environment. Structurally identical to MVTB's (`machinevision-toolbox-python`) `release.yml`, already running in production there — only the package/import name differs (bdsim's match, so no translation needed).

Removed the now-superseded `make upload` target — publishing a release becomes `gh release create vX.Y.Z` (or the GitHub UI), which fires this workflow. `make dist` stays, still useful for local sdist/wheel builds.

Only triggers on `release: types: [created]` or manual `workflow_dispatch`, never an ordinary push — inert until deliberately invoked.

## Still needed before this can do a real release
- [ ] Register bdsim's PyPI Trusted Publisher at pypi.org (manual, PyPI project owner only)
- [ ] Create the `pypi` GitHub Environment with a tag-restricted deployment policy + required reviewer

## Test plan
- [x] Valid YAML, diffed against MVTB's working `release.yml` — only the two package/import-name lines differ
- [ ] Dry-run via `workflow_dispatch` once the environment above exists, rejecting at the approval gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)