### PR TITLE
fix: disable JSPI-dependent run_until_complete in JupyterLite (Safari crash)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -59,6 +59,19 @@ jobs:
           cp docs/figs/*.png docs/figs/*.svg docs/lite/files/figs/
 
       - name: Build JupyterLite content
+        # docs/lite/jupyter-lite.json sets loadPyodideOptions.enableRunUntilComplete
+        # to false. Pyodide 0.27.7 (2025-06-04) turned this on by default, which
+        # makes any synchronous run_until_complete() call use WebAssembly JSPI
+        # ("stack switching") -- and hard-crash the kernel on browsers that don't
+        # support it, rather than the old harmless no-op. Chrome/Edge shipped JSPI;
+        # Firefox has it behind a flag; Safari has no support yet (dropped its
+        # standards objection in late 2025, so this may change). Since this repo
+        # installs jupyterlite-pyodide-kernel unpinned, any future "latest" bump
+        # picks up whatever Pyodide version ships that day -- this setting is what
+        # keeps the kernel usable in Safari regardless of that drift, at the cost
+        # of losing genuine synchronous-blocking semantics inside a cell (bdsim's
+        # notebooks don't need those). Once Safari (and Firefox out-of-flag) ship
+        # JSPI, flip this back to true -- don't just delete it silently.
         run: |
           cd docs/lite
           jupyter lite build --output-dir ../build/html/lite --contents files --force

--- a/docs/lite/jupyter-lite.json
+++ b/docs/lite/jupyter-lite.json
@@ -1,6 +1,13 @@
 {
     "jupyter-lite-schema-version": 0,
     "jupyter-config-data": {
-        "appUrl": "./lab/index.html?path=notebooks/bouncing-ball.ipynb"
+        "appUrl": "./lab/index.html?path=notebooks/bouncing-ball.ipynb",
+        "litePluginSettings": {
+            "@jupyterlite/pyodide-kernel-extension:kernel": {
+                "loadPyodideOptions": {
+                    "enableRunUntilComplete": false
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
Safari users hit "Python (Pyodide) | Initializing" forever, no cell ever executes — confirmed live via the browser console (repeated kernel death, unhandled promise rejection, and eventually a direct traceback: `RuntimeError: WebAssembly stack switching not supported in this JavaScript runtime`).

Root cause: Pyodide `0.27.7` (2025-06-04) turned `enableRunUntilComplete` on by default — any synchronous `run_until_complete()` call now uses WebAssembly JSPI ("stack switching"), which **crashes** on browsers without JSPI support instead of the old harmless no-op. Chrome/Edge support it; Firefox has it behind a flag; Safari has no support yet (dropped its standards objection in late 2025, so this may change).

This repo installs `jupyterlite-pyodide-kernel` unpinned. It bumped from `0.8.2` to `0.8.3` on 2026-08-11 — **mid-session, released the same day** — bundling Pyodide `314.0.4`, and the very next scheduled rebuild picked it up.

## Fix
Set `loadPyodideOptions.enableRunUntilComplete: false` in `docs/lite/jupyter-lite.json`, restoring the pre-`0.27.7` no-op behaviour. Confirmed via `jupyterlite-pyodide-kernel`'s own JSON schema (`packages/pyodide-kernel-extension/schema/kernel.v0.schema.json`) that `loadPyodideOptions` is a genuine documented passthrough straight into `loadPyodide()` — not a guess.

**Deliberately not pinning `jupyterlite-pyodide-kernel`** to an older version (e.g. RTB's `==0.6.1`, which happens to dodge this bug via an unrelated wasm-ABI-matching pin) — this keeps bdsim on the latest kernel/Pyodide rather than freezing a year in the past. The tradeoff: genuine synchronous-blocking semantics inside a cell stop working — not needed by any of bdsim's notebooks. Left a comment in `pages.yml` explaining this is meant to flip back to `true` once Safari (and Firefox out-of-flag) ship JSPI, not be silently deleted.

**MVTB has the same unpinned exposure** and no equivalent config — flagging as a follow-up, not fixed here.

## Test plan
- [x] Reproduced the actual CI pipeline (wheel build, `gen_index.py`, notebook-prep copy, `jupyter lite build`) locally against `jupyterlite-pyodide-kernel==0.8.3` — the exact version currently deployed and broken
- [x] Confirmed the built site's merged `jupyter-lite.json` carries `loadPyodideOptions: {enableRunUntilComplete: False}` through correctly
- [ ] Confirm in a real Safari session once deployed (can't test a browser runtime from here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)