### PR TITLE
fix: pin jupyterlite-pyodide-kernel==0.6.1, revert enableRunUntilComplete

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,11 +29,33 @@ jobs:
           python-version: "3.10"
 
       - name: Install dependencies
+        # jupyterlite-pyodide-kernel is pinned deliberately -- NOT for wasm-ABI
+        # matching (bdsim is pure Python, unlike RTB's compiled-extension pin of
+        # the same version, for a different reason). Newer kernel releases bundle
+        # Pyodide >=0.27.7, which turned WebAssembly JSPI ("stack switching") on
+        # by default for run_until_complete(). Browsers without JSPI support
+        # (Safari has none as of 2026-08; Firefox only behind a flag) used to
+        # hard-crash the kernel outright on this. Passing
+        # loadPyodideOptions.enableRunUntilComplete: false avoids the crash, but
+        # turns run_until_complete into a fire-and-forget no-op instead of a
+        # genuine synchronous wait -- and the kernel's own cell-execution driver
+        # relies on that wait actually completing before running a cell's
+        # auto-detected package/dynamic-library imports. Confirmed live: with
+        # that workaround, `import bdsim` intermittently failed with
+        # ModuleNotFoundError for matplotlib even though the preceding piplite
+        # install cell had already reported success -- the install just hadn't
+        # actually finished landing yet. jupyterlite-pyodide-kernel==0.6.1 bundles
+        # Pyodide 0.27.6, genuinely predating this whole mechanism, restoring
+        # correct (if slower) blocking behaviour -- matches RTB's existing pin.
+        # Installing jupyterlite-core directly rather than the jupyterlite
+        # metapackage: the metapackage requires jupyterlite-core>=0.8.1, which
+        # conflicts with this pin's jupyterlite-core<0.7.0 requirement.
+        # Once Safari (and Firefox out-of-flag) ship JSPI, revisit this pin.
         run: |
           python -m pip install --upgrade pip
           pip install .[dev,docs]
           pip install build
-          pip install jupyterlite jupyter-server jupyterlite-pyodide-kernel
+          pip install jupyterlite-core "jupyterlite-pyodide-kernel==0.6.1" jupyter-server
           sudo apt-get update
           sudo apt-get install -y graphviz
 
@@ -59,19 +81,6 @@ jobs:
           cp docs/figs/*.png docs/figs/*.svg docs/lite/files/figs/
 
       - name: Build JupyterLite content
-        # docs/lite/jupyter-lite.json sets loadPyodideOptions.enableRunUntilComplete
-        # to false. Pyodide 0.27.7 (2025-06-04) turned this on by default, which
-        # makes any synchronous run_until_complete() call use WebAssembly JSPI
-        # ("stack switching") -- and hard-crash the kernel on browsers that don't
-        # support it, rather than the old harmless no-op. Chrome/Edge shipped JSPI;
-        # Firefox has it behind a flag; Safari has no support yet (dropped its
-        # standards objection in late 2025, so this may change). Since this repo
-        # installs jupyterlite-pyodide-kernel unpinned, any future "latest" bump
-        # picks up whatever Pyodide version ships that day -- this setting is what
-        # keeps the kernel usable in Safari regardless of that drift, at the cost
-        # of losing genuine synchronous-blocking semantics inside a cell (bdsim's
-        # notebooks don't need those). Once Safari (and Firefox out-of-flag) ship
-        # JSPI, flip this back to true -- don't just delete it silently.
         run: |
           cd docs/lite
           jupyter lite build --output-dir ../build/html/lite --contents files --force

--- a/docs/lite/jupyter-lite.json
+++ b/docs/lite/jupyter-lite.json
@@ -1,13 +1,6 @@
 {
     "jupyter-lite-schema-version": 0,
     "jupyter-config-data": {
-        "appUrl": "./lab/index.html?path=notebooks/bouncing-ball.ipynb",
-        "litePluginSettings": {
-            "@jupyterlite/pyodide-kernel-extension:kernel": {
-                "loadPyodideOptions": {
-                    "enableRunUntilComplete": false
-                }
-            }
-        }
+        "appUrl": "./lab/index.html?path=notebooks/bouncing-ball.ipynb"
     }
 }


### PR DESCRIPTION
## Summary
The previous fix (#48, `loadPyodideOptions.enableRunUntilComplete: false`) avoided the Safari crash but traded it for a silent, harder-to-diagnose bug: it doesn't restore the old pre-0.27.7 blocking behaviour, it turns `run_until_complete` into a fire-and-forget `asyncio.ensure_future()` that never actually waits. `jupyterlite-pyodide-kernel`'s own cell-execution driver (`_load_packages_from_imports` in `kernel.py`) relies on that wait completing before running a cell's auto-detected package/dynamic-library imports.

Confirmed live: with that workaround, `import bdsim` intermittently failed with `ModuleNotFoundError` for `matplotlib` even though the preceding piplite install cell had already reported success — the install just hadn't actually finished landing yet (re-running the same cell afterwards worked, confirming a race rather than a real missing dependency).

## Fix
Switch to the fix RTB already uses in production, for an unrelated reason: pin `jupyterlite-pyodide-kernel==0.6.1`, which bundles Pyodide `0.27.6` — genuinely predating the whole JSPI/`enableRunUntilComplete` mechanism, so it never faces this fire-and-forget degradation at all. Also switches from the `jupyterlite` metapackage to `jupyterlite-core` directly: the metapackage requires `jupyterlite-core>=0.8.1`, which conflicts with `0.6.1`'s own `jupyterlite-core<0.7.0` requirement.

Considered `jupyterlite-xeus` instead (doesn't use Pyodide/JSPI at all — worker + `SharedArrayBuffer`/`Atomics.wait`, a much older and more widely-supported mechanism — likely avoids this whole class of bug structurally). Not pursued now: GitHub Pages doesn't support setting the COOP/COEP headers `SharedArrayBuffer` needs, and `xeus-python` installs packages from `emscripten-forge` at build time rather than PyPI at runtime — unverified whether `spatialmath-python`/`ansitable`/`progress` are available there. Worth a real look another time, not mid-incident. A tech-debt issue will track revisiting this pin (and reconsidering xeus) once Safari/Firefox ship JSPI, or in ~6 months regardless.

## Test plan
- [x] `jupyterlite-core 0.6.4` + `jupyterlite-pyodide-kernel 0.6.1` resolve with no conflicts, including alongside bdsim's full `[dev,docs]` extras
- [x] Real `jupyter lite build` against bdsim's actual current content succeeds: correct `notebooks/`+`figs/` output structure, kernel extension directory present (matches the "Validate JupyterLite kernel availability" check), no leftover `enableRunUntilComplete` config
- [ ] Confirm live in Safari once deployed: kernel initializes, `getting-started.ipynb`'s piplite-install cell then `import bdsim` both succeed reliably

🤖 Generated with [Claude Code](https://claude.com/claude-code)