### PR TITLE
fix: raw-string BlockDiagram.graph()'s docstring

### DIFF
--- a/src/bdsim/blockdiagram.py
+++ b/src/bdsim/blockdiagram.py
@@ -1588,7 +1588,7 @@ class BlockDiagram(BlockDiagramMixin):
         filename: str | io.TextIOWrapper | None = None,
         shapes: Any = None,
     ) -> str:
-        """Render diagram text in DOT, Mermaid, GraphML, or ELK JSON format.
+        r"""Render diagram text in DOT, Mermaid, GraphML, or ELK JSON format.
 
         :param format: graph output format: ``"dot"``, ``"mermaid"``,
             ``"mermaid_fenced"``, ``"graphml"`` or ``"elk"``


### PR DESCRIPTION
## Summary
`BlockDiagram.graph()`'s docstring contains a literal `` \`\`\`mermaid `` fence for its rendered example, but wasn't a raw string. `` \` `` isn't a recognized Python escape sequence, so every import raised `SyntaxWarning: invalid escape sequence '\`'` — visible in the test suite's own warning summary.

## Test plan
- [x] `compile()` of the module under `warnings.filterwarnings('error')` no longer raises
- [x] Full test suite still passes (439 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)