### PR TITLE
fix: bump numpy floor to >=2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.3.0"
 authors = [{ name = "Peter Corke", email = "rvc@petercorke.com" }]
 
 dependencies = [
-    "numpy>=1.17.4",
+    "numpy>=2",
     "scipy",
     "matplotlib",
     "spatialmath-python",


### PR DESCRIPTION
## Summary
`requires-python` is already `>=3.10` and CI only ever tests against whatever numpy resolves today (2.x) — the `>=1.17.4` floor was years stale and untested.

- No numpy 1.x-only APIs (`np.float_`, `np.NaN`, etc.) appear anywhere in `src/bdsim`.
- SMTB's own `numpy<2` constraint is scoped to its unrelated `[ros-humble]` extra, not its main dependency — doesn't conflict with anything bdsim actually pulls in.

## Test plan
- [x] Full test suite passes against numpy 2.5.0 (already the resolved version throughout this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)