### PR TITLE
docs: add GitHub link to Sphinx footer, matching SG's style

### DIFF
--- a/docs/source/_templates/footer.html
+++ b/docs/source/_templates/footer.html
@@ -1,0 +1,5 @@
+{% extends "!footer.html" %}
+{% block contentinfo %}
+  {{ super() }}
+  <a href="https://github.com/petercorke/bdsim" class="footer-github-link">GitHub</a>
+{% endblock %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,7 +37,7 @@ sys.path.append(os.path.abspath("exts"))
 # -- Project information -----------------------------------------------------
 
 project = "Block diagram simulation"
-copyright = "2020-, Peter Corke."
+copyright = "2020-present, Peter Corke"
 author = "Peter Corke"
 
 try:
@@ -103,6 +103,7 @@ html_theme_options = {
 
 html_logo = "../figs/bdsim_logo.png"
 html_last_updated_fmt = "%d-%b-%Y"
+show_authors = True
 autoclass_content = "class"
 html_show_sourcelink = True
 


### PR DESCRIPTION
## Summary
Adds a custom `_templates/footer.html` extending the RTD theme's default footer with a GitHub link, plus `show_authors = True` — matching the style already used on spatialgeometry's docs (jhavl.github.io/spatialgeometry), whose `footer.html` this is copied from (single-author copyright/author here, unlike SG's two authors).

Also fixes the `copyright` string, which was `"2020-, Peter Corke."` (dangling dash, trailing period) — now `"2020-present, Peter Corke"` matching SG's phrasing.

## Test plan
- [x] `make -C docs html` builds successfully
- [x] Rendered footer confirmed: `© Copyright 2020-present, Peter Corke.` + last-updated + GitHub link

🤖 Generated with [Claude Code](https://claude.com/claude-code)