### PR TITLE
docs: collapse README hero table to a single italic arrow line

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,7 @@
   <strong>A Pythonic block-diagram environment for the simulation and analysis of dynamic systems.</strong>
   <br><br>
 
-<table align="center" style="border: none; border-collapse: collapse;">
-  <tr>
-    <td style="border: none; font-size: 1.5em; padding: 2px 8px;">🧠</td>
-    <td style="border: none; font-size: 1.5em; padding: 2px 8px;">Block diagram thinking</td>
-  </tr>
-  <tr>
-    <td style="border: none; font-size: 1.5em; padding: 2px 8px;">🐍</td>
-    <td style="border: none; font-size: 1.5em; padding: 2px 8px;">Python coding</td>
-  </tr>
-</table>
+<p style="font-size: 1.5em;"><em>Block diagram thinking → Python coding</em></p>
 
 
 [![JupyterLite](https://img.shields.io/badge/Try_it_Now-JupyterLite-orange?style=for-the-badge&logo=jupyter)](https://petercorke.github.io/bdsim/lite/lab?path=notebooks/index.ipynb)


### PR DESCRIPTION
## Summary
Replaces the two-row emoji table ("Block diagram thinking" / "Python coding") with a single italicized line at the same font size, joined by a unicode arrow (→).

## About the Python-version badge
No code change needed here — `README.md:44`'s `pyversions` badge already queries the correct URL (`img.shields.io/pypi/pyversions/bdsim.svg`), and `pyproject.toml`'s classifiers were already fixed to list `3.10`–`3.13` explicitly (#42, merged). The badge just renders whatever PyPI's **currently published** version's metadata says, and PyPI still only has `1.2.2` (pre-dating that classifier fix) — it'll self-correct the moment `1.3.0` actually gets published. That's part of the still-pending release-automation work, not a README bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)