### PR TITLE
fix: release-please's Trigger PyPI publish step can't detect repo

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,3 +38,6 @@ jobs:
           gh workflow run release.yml --ref "$tag"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # No checkout step in this job, so gh can't auto-detect the repo
+          # from a local git remote -- tell it explicitly.
+          GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary
The `release-please` job has no `actions/checkout` step — never needed one for `release-please-action` itself, which talks to the GitHub API directly. But the "Trigger PyPI publish" step runs plain `gh` commands (`gh release list`, `gh workflow run`), and `gh` normally auto-detects which repo to operate on by running `git remote -v` in the current directory. With no checkout, there's no `.git` directory at all, so it failed outright: `failed to run git: fatal: not a git repository`.

Confirmed live: this step ran (`steps.release.outputs.releases_created` was truthy) on the merge that first added this workflow, even though `release-please-action`'s own log said "No user facing commits found... skipping" for that same run — no release/tag was actually created, so this was a harmless false trigger this time. But the same missing repo-context bug would break the real thing the next time a genuine release-please PR gets merged.

## Fix
Set `GH_REPO` explicitly so `gh` doesn't need to detect anything.

**Note:** MVTB's own `release-please.yml` (which this was copied from) has the identical gap and, as far as I can tell, has never actually exercised this step successfully either — worth checking there too.

## Test plan
- [x] Verified locally by running the same `gh` commands from a directory with no `.git` at all — fails without `GH_REPO`, succeeds with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)