### PR TITLE
ci: add dependabot for GitHub Actions, with patch/minor auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for patch/minor bumps
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' }}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
bdsim gained several new pinned-action workflows today (`release.yml`, `release-please.yml`, `commitlint.yml`) on top of the existing `ci.yml`/`pages.yml`/`publish.yml` — nothing was keeping any of those action versions current. Matches MVTB's existing setup: dependabot watches the `github-actions` ecosystem monthly, and patch/minor bumps auto-merge once CI passes (major bumps still need manual review). Dependabot's own PR titles aren't Conventional-Commit-formatted, but `commitlint.yml` already exempts `dependabot[bot]` from that check.

Copied verbatim from MVTB. Created the `dependencies` label referenced by `dependabot.yml`, which didn't exist on this repo yet.

## Test plan
- [x] Both new files valid YAML
- [ ] First dependabot run (next monthly schedule, or trigger manually via the Insights → Dependency graph → Dependabot tab) should open real PRs to confirm end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)