### PR TITLE
feat: add python -m bdsim and bdsim console script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ all = ["PySide6", "Pillow", "ipywidgets", "ipympl"]
 
 [project.scripts]
 
+bdsim = "bdsim.__main__:main"
 bdrun = "bdsim.bin.bdrun:bdrun"
 bdtex2icon = "bdsim.tex2icon:main"
 bdedit-app = "bdedit.make_app:make_app"

--- a/src/bdsim/__main__.py
+++ b/src/bdsim/__main__.py
@@ -1,0 +1,21 @@
+"""Command-line entry point for bdsim.
+
+Supports ``python -m bdsim`` and the ``bdsim`` console script. No diagram
+is built here, so introspection flags handled during :class:`BDSim`
+construction -- such as ``--blocks`` -- have nothing further to run and
+behave as print-and-exit.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from bdsim import BDSim
+
+
+def main() -> None:
+    BDSim(sysargs=sys.argv[1:])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `src/bdsim/__main__.py`, which does nothing but `BDSim(sysargs=sys.argv[1:])` and no diagram building. This enables `python -m bdsim` (Python requires a package's own `__main__.py` for the `-m` flag to work).
- Since no diagram is built, flags handled entirely inside `BDSim` construction — like `--blocks` — naturally have nothing further to run and behave as print-and-exit:
  ```
  python -m bdsim --blocks
  bdsim --blocks
  ```
- Registers a `bdsim` console script in `pyproject.toml` pointing at the same `main()`, alongside the existing `bdrun`/`bdedit`/`bdweb` scripts.
- No changes to `--blocks`' existing behaviour elsewhere (e.g. in example scripts, where it still prints then lets the script continue building/running its own diagram).

## Test plan
- [x] `python -m bdsim --blocks` — prints block registry, exits cleanly, no diagram/graphics touched
- [x] `bdsim --blocks` (console script, after `pip install -e .`) — same result
- [x] `python -m pytest -q` (full suite) — 439 passed, 9 skipped, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)