### PR TITLE
fix: PoseIntegrator_S/DPoseIntegrator crash with default x0

### DIFF
--- a/src/bdsim/blocks/spatial.py
+++ b/src/bdsim/blocks/spatial.py
@@ -336,7 +336,7 @@ class PoseIntegrator_S(SampledBlock):
         """
 
         if x0 is None:
-            x0 = Twist3()
+            x0 = Twist3().A
         elif isinstance(x0, SE3):
             x0 = Twist3(x0).A
         elif hasattr(x0, "A"):

--- a/tests/blocks/test_blocks_sampled.py
+++ b/tests/blocks/test_blocks_sampled.py
@@ -13,7 +13,7 @@ import numpy.testing as nt
 
 import bdsim
 from bdsim.blocks.sampled import *
-from bdsim.blocks.spatial import PoseIntegrator_S
+from bdsim.blocks.spatial import PoseIntegrator_S, DPoseIntegrator
 from spatialmath import SE3, Twist3
 
 
@@ -104,6 +104,16 @@ class DiscreteTest(unittest.TestCase):
         nt.assert_almost_equal(
             block.test_next(u, x=x), Twist3(T * SE3.Delta(u * clock.T))
         )
+
+    def test_pose_integrator_s_default_x0(self):
+
+        clock = Clock(2, "Hz")
+        block = PoseIntegrator_S(clock)  # x0 defaults to None -> null twist
+        nt.assert_equal(block.getstate0(), np.zeros(6))
+
+        with self.assertWarns(FutureWarning):
+            deprecated_block = DPoseIntegrator(clock)
+        nt.assert_equal(deprecated_block.getstate0(), np.zeros(6))
 
 
 class DiscreteTransferTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- `PoseIntegrator_S.__init__` reduces `x0` to a raw ndarray in every branch before calling `SampledBlock.__init__` (which expects plain array-like and has no pose-object handling of its own) — except the `x0 is None` branch, which left a bare `Twist3()` object instead of its `.A` array.
- Instantiating `PoseIntegrator_S(clock)` or `DPoseIntegrator(clock)` with no explicit `x0` (the documented default) raised `TypeError: invalid input type` from spatialmath's `getvector()`.
- The sibling continuous-time class, `PoseIntegrator`, already handles this case correctly (`np.zeros((6,))` for `x0 is None`) — ported the same fix: `Twist3().A` instead of bare `Twist3()`.
- Added a regression test (`test_pose_integrator_s_default_x0` in `tests/blocks/test_blocks_sampled.py`) covering both `PoseIntegrator_S` and `DPoseIntegrator` with default `x0`. Verified it fails with the original `TypeError` when the fix is reverted, and passes with the fix applied.

## Test plan
- [x] New regression test added; confirmed it reproduces the original crash on the pre-fix code and passes post-fix
- [x] `python -m pytest -q` (full suite) — 440 passed, 9 skipped, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)