### PR TITLE
fix: Scope(watch=True) crashed on start due to attribute typo

### DIFF
--- a/src/bdsim/blocks/displays.py
+++ b/src/bdsim/blocks/displays.py
@@ -554,7 +554,7 @@ class Scope(GraphicsBlock):
         _cursor_register_controls(self)
 
         if self.watch:
-            for wire in self.input_wires:  # type: ignore[attr-defined]
+            for wire in self._input_wires:  # type: ignore[attr-defined]
                 plug = wire.start  # start plug for input wire
 
                 # append to the watchlist, bdsim.run() will do the rest

--- a/tests/blocks/test_blocks_displays.py
+++ b/tests/blocks/test_blocks_displays.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+import unittest
+
+import matplotlib.pyplot as plt
+
+from bdsim import BDSim
+
+
+class ScopeWatchTest(unittest.TestCase):
+    def tearDown(self) -> None:
+        # Scope.start() creates a real matplotlib figure; close it so it
+        # doesn't leak into other tests' global figure state.
+        plt.close("all")
+
+    def test_watch_adds_input_source_to_watchlist(self):
+        sim = BDSim()  # create simulator
+        bd = sim.blockdiagram()
+        source = bd.CONSTANT(2)
+        scope = bd.SCOPE(watch=True)
+        bd.connect(source, scope)
+        bd.compile()
+
+        simstate = scope.test_start()
+
+        expected_plug = scope._input_wires[0].start
+        self.assertEqual(len(simstate.watchlist), 1)
+        self.assertIs(simstate.watchlist[0], expected_plug)
+        self.assertEqual(simstate.watchnamelist, [str(expected_plug)])
+
+    def test_no_watch_leaves_watchlist_empty(self):
+        sim = BDSim()
+        bd = sim.blockdiagram()
+        source = bd.CONSTANT(3)
+        scope = bd.SCOPE()  # watch defaults to False
+        bd.connect(source, scope)
+        bd.compile()
+
+        simstate = scope.test_start()
+
+        self.assertEqual(simstate.watchlist, [])
+        self.assertEqual(simstate.watchnamelist, [])
+
+
+# ---------------------------------------------------------------------------------------#
+if __name__ == "__main__":
+
+    unittest.main()


### PR DESCRIPTION
## Summary
- `Scope.start()` referenced `self.input_wires`, which doesn't exist — the real attribute (declared on `Block`) is `self._input_wires`.
- Any `SCOPE`/`Scope` block constructed with `watch=True` raised `AttributeError` as soon as the simulation started, instead of adding its input sources to the run's watchlist.
- No other spots in the codebase use the incorrect `.input_wires` name (checked via grep across `src/`, `tests/`, `examples/`).

## Test plan
- [x] Added `tests/blocks/test_blocks_displays.py`: `test_watch_adds_input_source_to_watchlist` (confirms the input source plug lands in `simstate.watchlist`/`watchnamelist`) and `test_no_watch_leaves_watchlist_empty` (control case, `watch=False`)
- [x] Confirmed the new test reproduces the original `AttributeError` when the fix is reverted, and passes with it applied
- [x] `python -m pytest -q` (full suite) — 441 passed, 9 skipped, no regressions (run 3x to confirm stability — the new test creates a real matplotlib figure via `Scope.start()`, so `tearDown` closes it to avoid leaking global figure state into unrelated tests like `test_display_manager.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)