### PR TITLE
docs: match Sphinx page footer to rvc-ecosystem convention

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,0 +1,15 @@
+/* Footer layout: copyright on the left, GitHub link on the right in smaller font. */
+div[role="contentinfo"] {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    flex-wrap: wrap;
+}
+
+div[role="contentinfo"] p {
+    margin: 0;
+}
+
+.footer-github-link {
+    font-size: 0.85em;
+}

--- a/docs/source/_templates/footer.html
+++ b/docs/source/_templates/footer.html
@@ -1,5 +1,13 @@
 {% extends "!footer.html" %}
 {% block contentinfo %}
-  {{ super() }}
+  <p>
+  {%- if show_copyright %}
+    {%- trans copyright=copyright|e %}Copyright &#169; {{ copyright }}{% endtrans -%}
+  {%- endif %}
+  {%- if last_updated %}
+    {%- trans last_updated=last_updated|e %}: built {{ last_updated }}{% endtrans %}
+  {%- endif -%}
+  .
+  </p>
   <a href="https://github.com/petercorke/bdsim" class="footer-github-link">GitHub</a>
 {% endblock %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -102,7 +102,7 @@ html_theme_options = {
 }
 
 html_logo = "../figs/bdsim_logo.png"
-html_last_updated_fmt = "%d-%b-%Y"
+html_last_updated_fmt = "%Y-%m-%d"
 show_authors = True
 autoclass_content = "class"
 html_show_sourcelink = True
@@ -159,6 +159,7 @@ mathjax3_config = {
 # -------- Options favicon -------------------------------------------------------#
 
 html_static_path = ["_static"]
+html_css_files = ["custom.css"]
 # create favicons online using https://favicon.io/favicon-converter/
 favicons = [
     {


### PR DESCRIPTION
## Summary
- The footer previously rendered `sphinx_rtd_theme`'s default text ("© Copyright 2020-present, Peter Corke. Last updated on DD-Mon-YYYY.") plus an unstyled GitHub link that fell inline below it — no CSS existed anywhere for `.footer-github-link`, so it never actually appeared "on right, in smaller font" as the rvc-ecosystem convention (`README.md`, which cites bdsim as the reference implementation for this pattern) describes.
- `footer.html`: builds the exact left-side text `Copyright © 20xx-present, Peter Corke: built YYYY-MM-DD` instead of the theme's two default sentences.
- `conf.py`: `html_last_updated_fmt` → `"%Y-%m-%d"` so the build date renders in that format; wires up `html_css_files`.
- `_static/custom.css` (new): flex layout on the footer's `contentinfo` div so the GitHub link actually sits on the right, in smaller font, as originally intended.

## Test plan
- [x] Local `sphinx-build` — no new warnings/errors
- [x] Verified exact rendered footer text: `Copyright © 2020-present, Peter Corke: built 2026-08-16.`
- [x] Verified `custom.css` is linked in `<head>` and copied to `_static/` in the build output

🤖 Generated with [Claude Code](https://claude.com/claude-code)