### PR TITLE
ci: add Python 3.14 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]

--- a/src/bdsim/blockdiagram.py
+++ b/src/bdsim/blockdiagram.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections import defaultdict
 import inspect
-import itertools
 from copy import deepcopy
 import io
 import json
@@ -56,7 +55,7 @@ class BlockDiagram(BlockDiagramMixin):
     :ivar compiled: diagram has successfully compiled
     :vartype compiled: bool
     :ivar blockcounter: unique counter for each block type
-    :vartype blockcounter: defaultdict of itertools.count
+    :vartype blockcounter: defaultdict of Counter
     :ivar blockdict: index of all blocks by category
     :vartype blockdict: dict of lists
     :ivar name: name of this diagram
@@ -75,9 +74,9 @@ class BlockDiagram(BlockDiagramMixin):
         self.blocklist: list[Block] = []  # list of all blocks
         self.clocklist: list[Clock] = []  # list of all clock sources
         self.compiled = False  # network has been compiled
-        self.blockcounter: defaultdict = defaultdict(itertools.count)
-        self._block_id_counter = itertools.count()
-        self._wire_id_counter = itertools.count()
+        self.blockcounter: defaultdict = defaultdict(Counter)
+        self._block_id_counter = Counter()
+        self._wire_id_counter = Counter()
         self.name: str = name
         self.nstates = 0
         self.ndstates = 0
@@ -85,11 +84,11 @@ class BlockDiagram(BlockDiagramMixin):
         self.blocknames: dict[str, Any] = {}
         self.options = None
         self.runtime: Any = None  # set by BDSim before compilation
-        self.n_auto_sum = itertools.count()
-        self.n_auto_prod = itertools.count()
-        self.n_auto_const = itertools.count()
-        self.n_auto_gain = itertools.count()
-        self.n_auto_pow = itertools.count()
+        self.n_auto_sum = Counter()
+        self.n_auto_prod = Counter()
+        self.n_auto_const = Counter()
+        self.n_auto_gain = Counter()
+        self.n_auto_pow = Counter()
         self._state_map: dict[Block, np.ndarray | None] = {}
         self.compiled = False
 

--- a/src/bdsim/blockdiagram.py
+++ b/src/bdsim/blockdiagram.py
@@ -35,6 +35,7 @@ else:
 
 
 from bdsim.components import *
+from bdsim.components import Counter
 from bdsim.connect import EndPlug, Plug, Port, StartPlug, Wire
 
 # ------------------------------------------------------------------------- #

--- a/src/bdsim/components.py
+++ b/src/bdsim/components.py
@@ -6,7 +6,6 @@ import threading
 import warnings
 import unicodedata
 import heapq
-import itertools
 from collections import UserDict
 
 import numpy as np
@@ -288,6 +287,27 @@ class OptionsBase(UserDict):
         return f"{self.__class__.__name__}({', '.join(f'{k}={v}' for k, v in self.data.items())})"
 
 
+class Counter:
+    """Simple auto-incrementing counter, a deepcopy-safe drop-in replacement
+    for ``itertools.count()``.
+
+    Python 3.14 removed pickle/copy/deepcopy support from itertools
+    iterators (deprecated since at least 3.12); a plain object with an int
+    attribute has no such restriction, since it goes through the default
+    ``__dict__``-copying path rather than itertools' C-level reduction.
+    """
+
+    __slots__ = ("_next",)
+
+    def __init__(self, start: int = 0) -> None:
+        self._next = start
+
+    def __next__(self) -> int:
+        value = self._next
+        self._next += 1
+        return value
+
+
 class TimeQ:
     """
     Time-ordered queue for events.
@@ -300,7 +320,7 @@ class TimeQ:
 
     def __init__(self) -> None:
         self._heap: list[tuple[float, int, Any]] = []
-        self._seq = itertools.count()
+        self._seq = Counter()
 
     def __len__(self) -> int:
         return len(self._heap)


### PR DESCRIPTION
## Summary
- Adds `3.14` to the CI test matrix (`ubuntu-latest`/`windows-latest`/`macos-latest` × `3.10`-`3.14`) and the corresponding PyPI classifier.
- Dependency readiness checked against live PyPI data: `numpy`, `scipy`, and `matplotlib` all publish full `cp314` wheels across Linux/macOS/Windows already. bdsim's own direct dependencies (`spatialmath-python`, `ansitable`, `progress`) are pure Python with no compiled extensions. bdsim is pure Python itself too (no nanobind/C++ build step like RTB/MVTB) — the lowest-risk of the "big 3" to pilot 3.14 support in, and the first of Peter's projects to do so.

## The 3.14 matrix legs found a real bug — fixed here too
`ubuntu-latest`/`windows-latest` py3.14 both failed on first push: `TypeError: cannot pickle 'itertools.count' object`. Root cause: Python 3.14 removes pickle/copy/deepcopy support from itertools iterators — deprecated since at least 3.12 via `DeprecationWarning: Pickle, copy, and deepcopy support will be removed from itertools in Python 3.14.` That warning has been firing on every run of `DeepCopyTest::test_deepcopy` (and any test creating a `SUBSYSTEM` block, which snapshots its diagram via `copy.deepcopy`) on **every** Python version, including our own local 3.12 — silently, since nothing turned it into a failure until an actual 3.14 interpreter did.

`BlockDiagram.__deepcopy__` generically deep-copies every instance attribute, including several `itertools.count()` counters used for block/wire IDs and auto-naming. Checked every one of the ~15 call sites across `block.py`/`connect.py`/`blockdiagram.py`: all of them only ever do `next(counter)` — nothing reads internal state, resets, or steps by anything but 1. So `components.Counter` (a minimal drop-in: an int in `__slots__`, implementing `__next__`) fixes it everywhere with **zero call-site changes**, and is trivially deepcopy-safe since it goes through the default `__dict__`/`__slots__`-copying path rather than itertools' C-level reduction. Also applied to `TimeQ._seq`, which uses the identical pattern and would have hit the same wall the first time anything deep-copies a `SimulationState`.

**Broader deprecation-warning audit** (since this one had clearly gone unnoticed): ran the full suite with all `DeprecationWarning`/`PendingDeprecationWarning`/`FutureWarning` surfaced, no filters found suppressing anything. Everything else is either one of bdsim's own intentional, properly-implemented deprecations (`blockinfo()`, `set_options()`, `report()` — each with a clear migration message) or an unrelated `UserWarning`/`UnicodeWarning`. One real one found outside bdsim's scope: `machinevision-toolbox-python`'s `Sources.py` uses `numpy.char.chararray`, itself deprecated — surfaces here via toolbox discovery, but belongs to a fix in that repo, not this PR.

3.10 is deliberately left in the matrix — its upcoming EOL is a separate, deliberate decision (would need its own `requires-python`/classifier/changelog treatment), out of scope for this change.

## Test plan
- [x] `python -m pytest -q` (full suite, local Python 3.12) — 442 passed, 9 skipped, no regressions
- [x] Verified `Counter`'s deepcopy semantics exactly match pre-3.14 `itertools.count()`: same next value preserved across the copy, independent afterward
- [x] Confirmed the itertools `DeprecationWarning` fired on every prior local test run, pre-dating this PR — not a new 3.14-only issue
- [x] CI: watching the `py3.14` matrix legs on this PR to confirm they now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)