### PR TITLE
feat: add BDSIM_NO_GRAPHICS envariable to force-disable graphics

### DIFF
--- a/src/bdsim/run_sim.py
+++ b/src/bdsim/run_sim.py
@@ -2875,6 +2875,8 @@ class Options(OptionsBase):
                     "Environment variables:\n"
                     "  BDSIM              comma-separated key=value pairs that set option defaults,\n"
                     "                     e.g. BDSIM=graphics=True,hold=True\n"
+                    "  BDSIM_NO_GRAPHICS  set to 1/true/yes/on to force graphics off, overriding\n"
+                    "                     code, BDSIM, and CLI args alike (e.g. for CI runs)\n"
                     "  BDSIMPATH          colon-separated list of extra paths/packages to search for blocks\n"
                     "  BDSIM_NO_TOOLBOXES set to 1/true/yes/on to skip loading external toolboxes\n"
                     "  BDSIM_DEBUG_LAZY_LOAD  set to any value to trace lazy block-class resolution\n"
@@ -3224,6 +3226,23 @@ class Options(OptionsBase):
         else:
             cmdline_options = dict()  # empty dictionary
             self._parser = None
+
+        # BDSIM_NO_GRAPHICS: unconditional override that forces graphics off,
+        # taking precedence over everything else -- code (BDSim(graphics=True)),
+        # the BDSIM envariable, and CLI args (+g/+a/-m) alike. Folded into
+        # cmdline_options (readonly) rather than default_options above, since
+        # readonly options can't be changed later via .set() or attribute
+        # assignment. Intended for CI / headless runs of example scripts that
+        # hard-code graphics=True.
+        if os.getenv("BDSIM_NO_GRAPHICS", "").strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }:
+            cmdline_options["graphics"] = False
+            cmdline_options["animation"] = False
+            cmdline_options["movies"] = None
 
         # Detect conflicting CLI options before normalizing
         if (

--- a/tests/test_run_sim.py
+++ b/tests/test_run_sim.py
@@ -1364,5 +1364,75 @@ class OptionsBackendCliTest(unittest.TestCase):
         self.assertEqual(opts.setglob, [])
 
 
+class OptionsNoGraphicsEnvTest(unittest.TestCase):
+    """Tests for the BDSIM_NO_GRAPHICS override (highest priority: beats
+    code kwargs, the BDSIM envariable, and explicit CLI flags alike)."""
+
+    def _parse_with_argv(self, argv):
+        old_argv = sys.argv[:]
+        try:
+            sys.argv = argv
+            return Options(sysargs=True)
+        finally:
+            sys.argv = old_argv
+
+    def _set_env(self, value):
+        old = os.environ.get("BDSIM_NO_GRAPHICS")
+        os.environ["BDSIM_NO_GRAPHICS"] = value
+        return old
+
+    def _restore_env(self, old):
+        if old is None:
+            os.environ.pop("BDSIM_NO_GRAPHICS", None)
+        else:
+            os.environ["BDSIM_NO_GRAPHICS"] = old
+
+    def test_unset_does_not_affect_graphics(self):
+        """Without the env var, graphics kwarg should be respected as normal."""
+        self.assertNotIn("BDSIM_NO_GRAPHICS", os.environ)
+        opts = Options(sysargs=False, graphics=True)
+        self.assertTrue(bool(opts.graphics))
+
+    def test_overrides_constructor_kwargs(self):
+        """Env var should force graphics/animation off even if code requests them."""
+        old = self._set_env("1")
+        try:
+            opts = Options(sysargs=False, graphics=True, animation=True)
+            self.assertFalse(bool(opts.graphics))
+            self.assertFalse(bool(opts.animation))
+            self.assertIsNone(opts.movies)
+        finally:
+            self._restore_env(old)
+
+    def test_overrides_explicit_cli_flags_without_raising(self):
+        """+g/+a on the CLI would normally conflict; the env var should win silently."""
+        old = self._set_env("true")
+        try:
+            opts = self._parse_with_argv(["prog", "+a"])
+            self.assertFalse(bool(opts.graphics))
+            self.assertFalse(bool(opts.animation))
+        finally:
+            self._restore_env(old)
+
+    def test_blocks_later_programmatic_set(self):
+        """graphics stays read-only afterwards, same as CLI-set options."""
+        old = self._set_env("yes")
+        try:
+            opts = Options(sysargs=False, graphics=True)
+            opts.set(graphics=True)
+            self.assertFalse(bool(opts.graphics))
+        finally:
+            self._restore_env(old)
+
+    def test_falsey_value_does_not_disable_graphics(self):
+        """An empty/unrecognised value should not trigger the override."""
+        old = self._set_env("0")
+        try:
+            opts = Options(sysargs=False, graphics=True)
+            self.assertTrue(bool(opts.graphics))
+        finally:
+            self._restore_env(old)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- New `BDSIM_NO_GRAPHICS` envariable (truthy check: `1`/`true`/`yes`/`on`) that unconditionally forces `graphics=False`, `animation=False`, `movies=None`
- Outranks every other way of setting these options: code kwargs (`BDSim(graphics=True)`), the `BDSIM` envariable, and explicit CLI flags (`+g`/`+a`/`-m`) — folded into the CLI's read-only option set so it also survives later programmatic `.set()` calls
- No conflict errors raised even if the script/CLI asks for animation or movies — the override applies before conflict detection, so it wins silently rather than crashing (useful for CI running example scripts headlessly)
- Documented in the `-h` epilog alongside the other `BDSIM_*` envariables

## Test plan
- [x] Added `OptionsNoGraphicsEnvTest` in `tests/test_run_sim.py`: unset is a no-op, overrides constructor kwargs, overrides explicit CLI flags without raising, blocks later `.set()` calls, ignores falsy values
- [x] `pytest tests/test_run_sim.py -k "OptionsNoGraphicsEnvTest or OptionsBackendCliTest"` — 26 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)