### PR TITLE
fix: Scope's watch=True silently no-ops when graphics is disabled

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -116,6 +116,7 @@ rst_epilog = """
 .. role:: raw-html(raw)
    :format: html
 .. |BlockOptions| replace:: :raw-html:`<a href="https://petercorke.github.io/bdsim/internals.html?highlight=block%20__init__#bdsim.Block.__init__">common Block options</a>`
+.. |GraphicsBlockOptions| replace:: :raw-html:`<a href="https://petercorke.github.io/bdsim/internals.html?highlight=graphicsblock%20__init__#bdsim.GraphicsBlock.__init__">common GraphicsBlock options</a>`
 """
 # -------- RVC maths notation -------------------------------------------------------#
 

--- a/src/bdsim/blocks/displays.py
+++ b/src/bdsim/blocks/displays.py
@@ -317,7 +317,6 @@ class Scope(GraphicsBlock):
         scale: Literal["auto"] | float = "auto",
         labels: list[str] | None = None,
         grid: bool | list | tuple = True,
-        watch: bool = False,
         title: str | None = None,
         loc: str = "best",
         **blockargs: Any,
@@ -340,13 +339,11 @@ class Scope(GraphicsBlock):
         :param grid: draw a grid, defaults to True. Can be boolean or a tuple of
                      options for grid()
         :type grid: bool or sequence
-        :param watch: add these signals to the watchlist, defaults to False
-        :type watch: bool, optional
         :param title: title of plot
         :type title: str
         :param loc: location of legend, see :meth:`matplotlib.pyplot.legend`, defaults to "best"
         :type loc: str
-        :param blockargs: :meth:`common block options <bdsim.Block.__init__>`
+        :param blockargs: |GraphicsBlockOptions|
         :type blockargs: dict
         """
 
@@ -416,7 +413,6 @@ class Scope(GraphicsBlock):
         self.line: list = [None] * nplots
         self.scale = scale
 
-        self.watch = watch
         self.title = title
         self.loc = loc
 
@@ -553,13 +549,6 @@ class Scope(GraphicsBlock):
         _cursor_add_owner(self)
         _cursor_register_controls(self)
 
-        if self.watch:
-            for wire in self._input_wires:  # type: ignore[attr-defined]
-                plug = wire.start  # start plug for input wire
-
-                # append to the watchlist, bdsim.run() will do the rest
-                simstate.watchlist.append(plug)
-                simstate.watchnamelist.append(str(plug))
         plt.draw()
 
     def step(self, t: float, inports: list[Any]) -> None:
@@ -777,7 +766,7 @@ class ScopeXY(GraphicsBlock):
         :type labels: 2-element tuple or list
         :param init: function to initialize the graphics, defaults to None
         :type init: callable
-        :param blockargs: :meth:`common block options <bdsim.Block.__init__>`
+        :param blockargs: |GraphicsBlockOptions|
         :type blockargs: dict
         """
 
@@ -1074,7 +1063,7 @@ class ScopeXY1(ScopeXY):
         :type labels: 2-element tuple or list
         :param init: function to initialize the graphics, defaults to None
         :type init: callable
-        :param blockargs: :meth:`common block options <bdsim.Block.__init__>`
+        :param blockargs: |GraphicsBlockOptions|
         :type blockargs: dict
         """
         super().__init__(
@@ -1144,7 +1133,7 @@ class Animation(GraphicsBlock):
         :type init: callable
         :param update: update function with signature update(frame, fig, ax)
         :type update: callable
-        :param blockargs: :meth:`common block options <bdsim.Block.__init__>`
+        :param blockargs: |GraphicsBlockOptions|
         :type blockargs: dict
         """
         super().__init__(**blockargs)

--- a/src/bdsim/graphics_block.py
+++ b/src/bdsim/graphics_block.py
@@ -57,6 +57,7 @@ class GraphicsBlock(SinkBlock):
         movie: str | None = None,
         timestamp: bool | None = None,
         timestamp_fmt: str | None = None,
+        watch: bool = False,
         **blockargs: Any,
     ) -> None:
         """
@@ -70,6 +71,9 @@ class GraphicsBlock(SinkBlock):
         :param timestamp_fmt: Format string used for timestamp text,
             defaults to ``TIMESTAMP_FORMAT``
         :type timestamp_fmt: str, optional
+        :param watch: add this block's input signal(s) to the watchlist,
+            defaults to False
+        :type watch: bool, optional
         :param blockargs: |BlockOptions|
         :type blockargs: dict
         :return: transfer function block base class
@@ -81,6 +85,7 @@ class GraphicsBlock(SinkBlock):
         self._graphics = True
         self._fig: matplotlib.figure.Figure | None = None
         self.ax: Any = None
+        self.watch = watch
         self._tile_subplotspec: Any = None
         self._movie = movie
         self._movie_started = False
@@ -133,6 +138,20 @@ class GraphicsBlock(SinkBlock):
 
         self._simstate = simstate
         self._enabled = simstate.options.graphics
+
+        if self.watch:
+            # watch-list registration is a data-collection concern, not a
+            # graphics one -- must happen even when graphics is disabled
+            # (eg. BDSIM_NO_GRAPHICS=1), otherwise out.y silently ends up
+            # empty instead of containing the watched signals. Lives here
+            # rather than in each subclass's start() so every GraphicsBlock
+            # gets it for free.
+            for wire in self._input_wires:  # type: ignore[attr-defined]
+                plug = wire.start  # start plug for input wire
+
+                # append to the watchlist, bdsim.run() will do the rest
+                simstate.watchlist.append(plug)
+                simstate.watchnamelist.append(str(plug))
 
         self._graphics_start_in_progress = True
         self._graphics_start_in_progress_run_id = run_id


### PR DESCRIPTION
## Summary
- `Scope.start()` registered `watch=True` signals into `simstate.watchlist` as part of its own graphics setup, guarded by an early `if not self._enabled: return`. With graphics disabled (eg. `BDSIM_NO_GRAPHICS=1`), that return skipped watch-list registration entirely -- `out.y` silently ended up missing/empty instead of containing the watched signals, with **no error raised**.
- Promoted `watch` to a `GraphicsBlock.__init__()` parameter and moved the registration logic into `GraphicsBlock.start()`, ahead of the graphics-enabled branch, so it now runs unconditionally. Any `GraphicsBlock` subclass that sets `self.watch = True` gets correct behaviour for free, not just `Scope`.
- Removed the now-redundant `watch` parameter from `Scope.__init__()` (inherited via `**blockargs`).
- Added `|GraphicsBlockOptions|` (mirroring the existing `|BlockOptions|`) and pointed `Scope`/`ScopeXY`/`ScopeXY1`/`Animation`'s `blockargs` docstrings at it instead of the `Block`-only link, since their `**blockargs` now also flows through `GraphicsBlock`'s own kwargs (`movie`, `timestamp`, `timestamp_fmt`, `watch`), not just `Block`'s.

Surfaced by RVC3-python's chap15 notebook (`IBVS-main.py`, an `opspace`-style `.bd` model with 3 `watch=True` SCOPE blocks) failing with `AttributeError: y2` only under headless/`BDSIM_NO_GRAPHICS` test runs -- worked fine with graphics on, which is what made it easy to miss.

## Test plan
- [x] `pytest tests/` -- 449 passed, 9 pre-existing skips (no regressions)
- [x] Confirmed `out.y` shape/`ynames` identical with `BDSIM_NO_GRAPHICS=1` set vs. unset, for a 3-watch-signal `.bd` model