### PR TITLE
fix: watch-list wiring, named-port assignment, and out.y0/y1 deprecation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -116,6 +116,7 @@ rst_epilog = """
 .. role:: raw-html(raw)
    :format: html
 .. |BlockOptions| replace:: :raw-html:`<a href="https://petercorke.github.io/bdsim/internals.html?highlight=block%20__init__#bdsim.Block.__init__">common Block options</a>`
+.. |GraphicsBlockOptions| replace:: :raw-html:`<a href="https://petercorke.github.io/bdsim/internals.html?highlight=graphicsblock%20__init__#bdsim.GraphicsBlock.__init__">common GraphicsBlock options</a>`
 """
 # -------- RVC maths notation -------------------------------------------------------#
 

--- a/src/bdsim/block.py
+++ b/src/bdsim/block.py
@@ -1138,7 +1138,7 @@ class Block(ABC, Port):
         if inport_names is not None and name in (inport_names or []):
             # we're doing wiring
             port = inport_names.index(name)
-            self.bd.connect(value, Plug(value, port=0))
+            self.bd.connect(value, Plug(self, port=port))
         else:
             # regular case, add attribute
             super().__setattr__(name, value)

--- a/src/bdsim/blocks/displays.py
+++ b/src/bdsim/blocks/displays.py
@@ -317,7 +317,6 @@ class Scope(GraphicsBlock):
         scale: Literal["auto"] | float = "auto",
         labels: list[str] | None = None,
         grid: bool | list | tuple = True,
-        watch: bool = False,
         title: str | None = None,
         loc: str = "best",
         **blockargs: Any,
@@ -340,13 +339,11 @@ class Scope(GraphicsBlock):
         :param grid: draw a grid, defaults to True. Can be boolean or a tuple of
                      options for grid()
         :type grid: bool or sequence
-        :param watch: add these signals to the watchlist, defaults to False
-        :type watch: bool, optional
         :param title: title of plot
         :type title: str
         :param loc: location of legend, see :meth:`matplotlib.pyplot.legend`, defaults to "best"
         :type loc: str
-        :param blockargs: :meth:`common block options <bdsim.Block.__init__>`
+        :param blockargs: |GraphicsBlockOptions|
         :type blockargs: dict
         """
 
@@ -416,7 +413,6 @@ class Scope(GraphicsBlock):
         self.line: list = [None] * nplots
         self.scale = scale
 
-        self.watch = watch
         self.title = title
         self.loc = loc
 
@@ -553,13 +549,6 @@ class Scope(GraphicsBlock):
         _cursor_add_owner(self)
         _cursor_register_controls(self)
 
-        if self.watch:
-            for wire in self._input_wires:  # type: ignore[attr-defined]
-                plug = wire.start  # start plug for input wire
-
-                # append to the watchlist, bdsim.run() will do the rest
-                simstate.watchlist.append(plug)
-                simstate.watchnamelist.append(str(plug))
         plt.draw()
 
     def step(self, t: float, inports: list[Any]) -> None:
@@ -777,7 +766,7 @@ class ScopeXY(GraphicsBlock):
         :type labels: 2-element tuple or list
         :param init: function to initialize the graphics, defaults to None
         :type init: callable
-        :param blockargs: :meth:`common block options <bdsim.Block.__init__>`
+        :param blockargs: |GraphicsBlockOptions|
         :type blockargs: dict
         """
 
@@ -1074,7 +1063,7 @@ class ScopeXY1(ScopeXY):
         :type labels: 2-element tuple or list
         :param init: function to initialize the graphics, defaults to None
         :type init: callable
-        :param blockargs: :meth:`common block options <bdsim.Block.__init__>`
+        :param blockargs: |GraphicsBlockOptions|
         :type blockargs: dict
         """
         super().__init__(
@@ -1144,7 +1133,7 @@ class Animation(GraphicsBlock):
         :type init: callable
         :param update: update function with signature update(frame, fig, ax)
         :type update: callable
-        :param blockargs: :meth:`common block options <bdsim.Block.__init__>`
+        :param blockargs: |GraphicsBlockOptions|
         :type blockargs: dict
         """
         super().__init__(**blockargs)

--- a/src/bdsim/components.py
+++ b/src/bdsim/components.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import threading
 import warnings
 import unicodedata
@@ -41,6 +42,9 @@ def oodebug(func: _F) -> _F:
         return ret
 
     return wrapper  # type: ignore[return-value]
+
+
+_legacy_watch_attr_re = re.compile(r"^y(\d+)$")
 
 
 # remove LaTeX characters from names for use in port names, etc.
@@ -117,8 +121,29 @@ class BDStruct(UserDict):
         # Allow attribute access to dot-prefixed hidden fields, e.g. out.stats → out[".stats"]
         try:
             return self.data["." + name]
-        except KeyError as err:
-            raise AttributeError(name) from err
+        except KeyError:
+            pass
+        # Deprecated per-signal watch attributes. out.y0, out.y1, ... used to
+        # each hold one watched signal's samples; they were replaced by
+        # out.y (all watched signals column-stacked into one array, see
+        # out.ynames for column order). Kept working here, against the
+        # pre-stack arrays saved under ".ywatch", so old scripts don't break
+        # outright.
+        m = _legacy_watch_attr_re.match(name)
+        if m is not None and ".ywatch" in self.data:
+            index = int(m.group(1))
+            ywatch = self.data[".ywatch"]
+            if 0 <= index < len(ywatch):
+                warnings.warn(
+                    f"out.{name} is deprecated and will be removed in a "
+                    f"future release; use out.y[:, {index}] instead "
+                    "(out.ynames gives the column order for multi-signal "
+                    "watches).",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                return ywatch[index]
+        raise AttributeError(name)
 
     def __setattr__(self, name: str, value: Any) -> None:
         if name.startswith("_") or name == "data":

--- a/src/bdsim/graphics_block.py
+++ b/src/bdsim/graphics_block.py
@@ -57,6 +57,7 @@ class GraphicsBlock(SinkBlock):
         movie: str | None = None,
         timestamp: bool | None = None,
         timestamp_fmt: str | None = None,
+        watch: bool = False,
         **blockargs: Any,
     ) -> None:
         """
@@ -70,6 +71,9 @@ class GraphicsBlock(SinkBlock):
         :param timestamp_fmt: Format string used for timestamp text,
             defaults to ``TIMESTAMP_FORMAT``
         :type timestamp_fmt: str, optional
+        :param watch: add this block's input signal(s) to the watchlist,
+            defaults to False
+        :type watch: bool, optional
         :param blockargs: |BlockOptions|
         :type blockargs: dict
         :return: transfer function block base class
@@ -81,6 +85,7 @@ class GraphicsBlock(SinkBlock):
         self._graphics = True
         self._fig: matplotlib.figure.Figure | None = None
         self.ax: Any = None
+        self.watch = watch
         self._tile_subplotspec: Any = None
         self._movie = movie
         self._movie_started = False
@@ -133,6 +138,20 @@ class GraphicsBlock(SinkBlock):
 
         self._simstate = simstate
         self._enabled = simstate.options.graphics
+
+        if self.watch:
+            # watch-list registration is a data-collection concern, not a
+            # graphics one -- must happen even when graphics is disabled
+            # (eg. BDSIM_NO_GRAPHICS=1), otherwise out.y silently ends up
+            # empty instead of containing the watched signals. Lives here
+            # rather than in each subclass's start() so every GraphicsBlock
+            # gets it for free.
+            for wire in self._input_wires:  # type: ignore[attr-defined]
+                plug = wire.start  # start plug for input wire
+
+                # append to the watchlist, bdsim.run() will do the rest
+                simstate.watchlist.append(plug)
+                simstate.watchnamelist.append(str(plug))
 
         self._graphics_start_in_progress = True
         self._graphics_start_in_progress_run_id = run_id

--- a/src/bdsim/run_sim.py
+++ b/src/bdsim/run_sim.py
@@ -149,6 +149,40 @@ def blockname(name: str) -> str:
     return name.upper()
 
 
+def _store_watch_output(
+    out: BDStruct,
+    watchlist: list[Plug],
+    watchnamelist: list[str],
+    plist: list[list[Any]],
+) -> None:
+    """Save watched-signal data into ``out.y``/``out.ynames``.
+
+    :param out: results struct being built for :meth:`BDSim.run`
+    :type out: BDStruct
+    :param watchlist: watched plugs, in column order
+    :type watchlist: list of Plug
+    :param watchnamelist: display name for each entry in ``watchlist``
+    :type watchnamelist: list of str
+    :param plist: per-signal logged samples, one list per ``watchlist`` entry
+    :type plist: list of list
+
+    ``out.y`` column-stacks every watched signal into one array (a signal
+    logging ``ndarray(k)`` samples contributes ``k`` columns), with
+    ``out.ynames`` giving the watched-plug name for each contributing
+    signal. The pre-stack, per-signal arrays are also kept (hidden) so that
+    the legacy ``out.y0``, ``out.y1``, ... accessors -- one array per
+    watched signal, replaced when watched signals were combined into
+    ``out.y`` -- keep working via :meth:`BDStruct.__getattr__`, with a
+    deprecation warning.
+    """
+    if not plist:
+        return
+    ywatch = [np.array(p) for p in plist]
+    out["y"] = np.column_stack(ywatch)
+    out["ynames"] = list(watchnamelist)
+    out[".ywatch"] = ywatch
+
+
 class _LazyBlockClass:
     """Proxy object that resolves a block class on first use."""
 
@@ -1371,9 +1405,7 @@ class BDSim(Runner):
                         legacy_name = str(c.name).replace(".", "")
                         if legacy_name != name and legacy_name not in out:
                             out.add(legacy_name, clockdata)
-                    for i, p in enumerate(watchlist):
-                        out["y" + str(i)] = np.array(simstate.plist[i])
-                    out["ynames"] = watchnamelist
+                    _store_watch_output(out, watchlist, watchnamelist, simstate.plist)
                     stats = BDStruct(name="stats")
                     stats["integration_time_points"] = len(simstate.tlist)
                     stats["run_interval_calls"] = simstate.stats.run_interval_calls
@@ -1622,12 +1654,7 @@ class BDSim(Runner):
                 clockdata["Xnames"] = c.statenames
                 out.add(name, clockdata)
 
-            # save the watchlist into variables named y0, y1 etc.
-            # for i, p in enumerate(watchlist):
-            #     out["y" + str(i)] = np.array(simstate.plist[i])
-            if simstate.plist:
-                out["y"] = np.column_stack([np.array(p) for p in simstate.plist])
-                out["ynames"] = [p.block.name for p in watchlist]
+            _store_watch_output(out, watchlist, watchnamelist, simstate.plist)
 
             stats = BDStruct(name="stats")
             stats["integration_time_points"] = len(simstate.tlist)

--- a/tests/test_blockdiagram.py
+++ b/tests/test_blockdiagram.py
@@ -308,6 +308,44 @@ class WiringTest(unittest.TestCase):
         bd.evaluate({}, 0)
         self.assertEqual(dst.inport_values, [5, 4, 3, 2])
 
+    def test_named_port_assignment_block(self):
+        """dst.portname = block must wire block's output to dst's named
+        input port (regression: it wired the block's own output back into
+        its own input instead, leaving dst unconnected)."""
+        bd = self.sim.blockdiagram()
+
+        const = bd.CONSTANT(5)
+        src = bd.GAIN(2)
+        bd.connect(const, src)
+        other = bd.CONSTANT(9)
+
+        dst = bd.NULL(2, inames=("x", "y"))
+        dst.x = src
+        dst.y = other
+
+        bd.compile(verbose=False)
+        bd.evaluate({}, 0)
+        self.assertEqual(dst.inport_values, [10, 9])
+
+    def test_named_port_assignment_plug(self):
+        """dst.portname = block[port] must wire the given output port to
+        dst's named input port (regression: AttributeError, since the Plug
+        being assigned was wrapped inside another Plug instead of being
+        connected to dst's named port)."""
+        bd = self.sim.blockdiagram()
+
+        const = bd.CONSTANT([2, 3, 4, 5])
+        src = bd.DEMUX(4)
+        bd.connect(const, src)
+
+        dst = bd.NULL(2, inames=("x", "y"))
+        dst.x = src[1]
+        dst.y = src[3]
+
+        bd.compile(verbose=False)
+        bd.evaluate({}, 0)
+        self.assertEqual(dst.inport_values, [3, 5])
+
     def test_chain1(self):
         bd = self.sim.blockdiagram()
 

--- a/tests/test_run_sim.py
+++ b/tests/test_run_sim.py
@@ -26,6 +26,7 @@ import contextlib
 from types import SimpleNamespace
 
 import numpy as np
+import numpy.testing as nt
 from matplotlib import animation
 
 import bdsim
@@ -303,6 +304,45 @@ class SimRunCoverageTest(unittest.TestCase):
         self.assertIsNotNone(out.t)
         self.assertIsNotNone(out.y)
         self.assertGreater(len(out.y), 0)
+
+    def test_run_watch_legacy_yN_attrs_match_y_columns(self):
+        """out.y0, out.y1, ... (pre-out.y column-stacking API) must still
+        work, warning DeprecationWarning, and match the corresponding
+        column of out.y; an out-of-range index still raises AttributeError."""
+        bd, step, integ, null = self._stateful_bd()
+        out = self.sim.run(bd, T=1, watch=[step, integ])
+
+        with self.assertWarns(DeprecationWarning):
+            y0 = out.y0
+        with self.assertWarns(DeprecationWarning):
+            y1 = out.y1
+        nt.assert_array_equal(y0, out.y[:, 0])
+        nt.assert_array_equal(y1, out.y[:, 1])
+
+        with self.assertRaises(AttributeError):
+            out.y2
+
+    def test_run_watch_pure_discrete_early_exit_uses_y_not_yN(self):
+        """A STOP that fires at t=0 (no continuous state) takes a separate
+        early-return path that used to build out.y0, out.y1, ... directly
+        instead of out.y (regression: diverged from the normal-exit path,
+        so the same watch= feature behaved differently depending on when
+        the simulation stopped)."""
+        bd = self.sim.blockdiagram()
+        clock = bd.clock(10, "Hz")
+        src = bd.WAVEFORM("sine", freq=1.0, offset=1.0, clock=clock)
+        stop = bd.STOP(lambda x: x > 0.5)
+
+        bd.connect(src, stop)
+        bd.compile(verbose=False)
+
+        out = self.sim.run(bd, T=10.0, watch=[src])
+
+        self.assertEqual(len(out.t), 1)
+        self.assertIsNotNone(out.y)
+        with self.assertWarns(DeprecationWarning):
+            y0 = out.y0
+        nt.assert_array_equal(y0, out.y[:, 0])
 
     # ---- simtime option ----------------------------------------------------
 


### PR DESCRIPTION
## Summary

Three related fixes to block-diagram wiring and watched-signal output, bundled on this branch (it started as a local integration test combining the first two, and this PR adds the third on top):

- **Scope `watch=True` silently no-ops when graphics is disabled** (already reviewed separately in #75, included here via merge). `Scope.start()` registered watched signals into `simstate.watchlist` as part of its graphics setup, guarded by an early `if not self._enabled: return` — with graphics disabled, that skipped watch-list registration entirely with no error. Moved to `GraphicsBlock.start()`, before the graphics-enabled branch, so it runs unconditionally.

- **Named-port assignment (`block.portname = value`) wired the wrong plug.** `Block.__setattr__`'s wiring path built the destination `Plug` from `value` (the RHS) with a hard-coded `port=0`, instead of from `self` at the resolved port index. Depending on the RHS type this either crashed (`AttributeError: 'Plug' object has no attribute '_bd'`) or silently wired a block's output back into its own input, leaving the real target port unconnected.

- **`out.y0`/`out.y1`/... broke silently when watched-signal output moved to `out.y`.** Watched signals used to come back as separate `out.y0`, `out.y1`, ... arrays; a later change column-stacked them into a single `out.y` (with `out.ynames` for column order), breaking old scripts with no warning and no working fallback. `BDStruct.__getattr__` now recognizes the legacy `yN` pattern and returns the matching pre-stack column with a `DeprecationWarning` pointing at `out.y[:, N]`. This also fixes an inconsistency where the pure-discrete early-exit path (a STOP condition true at `t=0`) never went through the `out.y` migration at all, so the same `watch=` feature produced different output shapes depending on when the simulation stopped.

## Test plan

- [x] `pytest tests/` — 453 passed, 9 skipped
- [x] New regression tests added for named-port assignment (`tests/test_blockdiagram.py`) and the `out.y0`/`out.y1` deprecation + early-exit consistency (`tests/test_run_sim.py`), each verified to fail against the pre-fix code and pass against the fix