### PR TITLE
docs: sync Sphinx docs with wiki, fix cross-references and drift

### DIFF
--- a/docs/notebooks/getting-started.ipynb
+++ b/docs/notebooks/getting-started.ipynb
@@ -402,7 +402,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bd.report()"
+    "bd.report_summary()"
    ]
   },
   {

--- a/docs/source/bdsim.blocks.rst
+++ b/docs/source/bdsim.blocks.rst
@@ -9,7 +9,7 @@ Block library
 The block diagrams comprise blocks which belong to one of a number of different categories. These come from
 the package ``bdsim.blocks``, ``roboticstoolbox.blocks``, ``machinevisiontoolbox.blocks``.
 
-Icons, if shown to the left of the black header bar, are as used with `bdedit <https://github.com/petercorke/bdsim/tree/master/bdsim/bdedit>`_.
+Icons, if shown to the left of the black header bar, are as used with `bdedit <https://github.com/petercorke/bdsim/tree/main/src/bdedit>`_.
 
 .. inheritance-diagram:: bdsim.components.SourceBlock bdsim.components.SinkBlock bdsim.graphics.GraphicsBlock bdsim.components.FunctionBlock bdsim.components.ContinuousBlock bdsim.components.SampledBlock bdsim.components.SubsystemBlock
    :caption: Block class hierarchy, arrow from parent class to subclass

--- a/docs/source/bdsim.rst
+++ b/docs/source/bdsim.rst
@@ -25,7 +25,7 @@ which we can express concisely with ``bdsim`` as (see `bdsim/examples/eg1.py <ht
    sum = bd.SUM('+-')
    gain = bd.GAIN(10)
    plant = bd.LTI_SISO(0.5, [2, 1], name='plant')
-   scope = bd.SCOPE(styles=['k', 'r--'], movie='eg1.mp4')
+   scope = bd.SCOPE(styles=['k', 'r--'])
 
    # connect the blocks
    bd.connect(demand, sum[0], scope[1])
@@ -91,17 +91,22 @@ instances.
 
 
 *  **Line 22** executes the simulation for the specified duration (5 seconds).
-*  **Line 26** (if uncommented) saves the scope content to a file named ``scope0.pdf``.
-*  **Line 27** blocks the script execution until figure windows are closed or a SIGINT is received.
 
-The simulation results are returned in a simple container object:
+To record a movie of a graphics block instead of (or as well as) displaying it live, pass
+``movie='filename.mp4'`` to that block's constructor (requires ``ffmpeg``); to keep figure windows
+open and interactive after the run finishes, call ``sim.done(bd, block=True)`` — both shown in the
+next example below.
+
+The simulation results are returned in a simple container object (see the wiki's `Simulation results
+<https://github.com/petercorke/bdsim/wiki/Simulation-results>`_ page for the full picture, including
+discrete/clocked state):
 
 .. code-block:: python
 
    >>> print(out)
    t      = ndarray:float64 (123,)
    x      = ndarray:float64 (123, 1)
-   xnames = ['plant:x_0'] (list)      
+   xnames = ['plant:x_0'] (list)
 
 To record additional simulation variables, use a ``WATCH`` block or the ``watch`` option in ``run``:
 
@@ -113,8 +118,12 @@ To record additional simulation variables, use a ``WATCH`` block or the ``watch`
    x      = ndarray:float64 (123, 1)
    xnames = ['plant:x_0'] (list)
    y      = ndarray:float64 (123, 2)
-   ynames = ['demand', 'sum.0'] (list)
+   ynames = ["Block.continuous('plant', type=lti_siso, nin=1, nout=1, nstates=1)[0]",
+             "Block.source('demand', type=step, nout=1)[0]"] (list)
    >>> plt.plot(out.t, out.y[:,0], 'k', out.t, out.y[:,1], 'r--')
+
+``ynames`` defaults to each watched block/plug's full ``repr()`` as shown above; it's usually clearer
+in practice, since ``demand`` and ``plant`` already have names here.
 
 Using operator overloading
 --------------------------
@@ -143,7 +152,7 @@ logic and Pythonic programming:
    plant[0] = 10 * (demand - plant)
 
    bd.compile()
-   bd.report()
+   bd.report_summary()
 
    out = sim.run(bd, 5)
    print(out)
@@ -158,21 +167,26 @@ automatically named with an underscore prefix.
 A list of available blocks can be obtained by::
 
    >>> sim.blocks()
-   bdsim.blocks.connections................: ITEM DICT MUX DEMUX INDEX SUBSYSTEM INPORT OUTPORT 
-   bdsim.blocks.continuous.................: INTEGRATOR POSEINTEGRATOR LTI_SS LTI_SISO DERIV2 DERIV PID 
-   bdsim.blocks.displays...................: SCOPE SCOPEXY SCOPEXY1 
-   bdsim.blocks.functions..................: SUM PROD GAIN POW CLIP FUNCTION INTERPOLATE 
-   bdsim.blocks.linalg.....................: INVERSE TRANSPOSE NORM FLATTEN SLICE2 SLICE1 DET COND 
-   bdsim.blocks.sampled....................: ZOH INTEGRATOR_S POSEINTEGRATOR_S DERIV_S LTI_SS_S LTI_SISO_S PID_S 
-   ........................................: DPOSEINTEGRATOR 
-   bdsim.blocks.sinks......................: PRINT STOP EVENT NULL WATCH 
-   bdsim.blocks.sources....................: CONSTANT TIME WAVEFORM PIECEWISE STEP RAMP 
-   roboticstoolbox.blocks.arm..............: FKINE IKINE JACOBIAN ARMPLOT JTRAJ CTRAJ CIRCLEPATH TRAPEZOIDAL TRAJ IDYN 
-   ........................................: GRAVLOAD_X INERTIA INERTIA_X FDYN FDYN_X 
-   roboticstoolbox.blocks.mobile...........: BICYCLE UNICYCLE DIFFSTEER VEHICLEPLOT 
-   roboticstoolbox.blocks.spatial..........: TR2DELTA DELTA2TR POINT2TR TR2T 
-   roboticstoolbox.blocks.uav..............: MULTIROTOR MULTIROTORMIXER MULTIROTORPLOT 
-   machinevisiontoolbox.blocks.camera......: CAMERA VISJAC_P ESTPOSE_P IMAGEPLANE 
+   89  blocks loaded
+   bdsim.blocks.connections................: ITEM DICT MUX DEMUX INDEX SUBSYSTEM INPORT OUTPORT
+   bdsim.blocks.continuous.................: INTEGRATOR LTI_SS LTI_SISO DERIV2 DERIV PID
+   bdsim.blocks.displays...................: SCOPE SCOPEXY SCOPEXY1 ANIMATION
+   bdsim.blocks.functions..................: SUM PROD GAIN POW CLIP FUNCTION INTERPOLATE
+   bdsim.blocks.linalg.....................: INVERSE TRANSPOSE NORM FLATTEN SLICE2 SLICE1 DET COND
+   bdsim.blocks.sampled....................: ZOH INTEGRATOR_S DERIV_S LTI_SS_S LTI_SISO_S PID_S DINTEGRATOR
+   bdsim.blocks.sinks......................: PRINT STOP EVENT NULL WATCH
+   bdsim.blocks.sources....................: CONSTANT TIME WAVEFORM PIECEWISE STEP RAMP
+   bdsim.blocks.spatial....................: POSE_POSTMUL POSE_PREMUL TRANSFORM_VECTOR POSE_INVERSE POSEINTEGRATOR
+   ........................................: DPOSEINTEGRATOR
+   roboticstoolbox.blocks.arm..............: FKINE IKINE JACOBIAN ARMPLOT JTRAJ CTRAJ CIRCLEPATH TRAPEZOIDAL TRAJ IDYN
+   ........................................: GRAVLOAD_X INERTIA INERTIA_X FDYN FDYN_X
+   roboticstoolbox.blocks.mobile...........: BICYCLE UNICYCLE DIFFSTEER VEHICLEPLOT
+   roboticstoolbox.blocks.spatial..........: TR2DELTA DELTA2TR POINT2TR TR2T
+   roboticstoolbox.blocks.uav..............: MULTIROTOR MULTIROTORMIXER MULTIROTORPLOT
+   machinevisiontoolbox.blocks.camera......: CAMERA VISJAC_P ESTPOSE_P IMAGEPLANE
+
+(the hardware I/O blocks, ``bdsim.blocks.io``, live on the unmerged ``feat/realtime`` branch, not
+``main`` — see the wiki's `Real-time overview <https://github.com/petercorke/bdsim/wiki/Real-time-overview>`_)
 
 More details can be found at:
 
@@ -180,6 +194,9 @@ More details can be found at:
    - `Adding blocks <https://github.com/petercorke/bdsim/wiki/Adding-blocks>`_
    - `Connecting blocks <https://github.com/petercorke/bdsim/wiki/Connecting-blocks>`_
    - `Running the simulation <https://github.com/petercorke/bdsim/wiki/Running>`_
+   - `What's in the results struct <https://github.com/petercorke/bdsim/wiki/Simulation-results>`_
+   - `Animation and movies <https://github.com/petercorke/bdsim/wiki/Animation-and-movies>`_
+   - `Time stepping: integration, animation & events <https://github.com/petercorke/bdsim/wiki/Time-stepping>`_
 - :ref:`Block library`
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,6 +41,9 @@ dictionaries, NumPy arrays, custom objects, and even functions—enabling a leve
 architectural flexibility and complexity that is difficult to achieve in graphical
 environments.
 
+This site is the class and method API reference. For tutorials, worked examples, and "under the
+hood" design notes, see the `bdsim wiki <https://github.com/petercorke/bdsim/wiki>`_.
+
 .. toctree::
    :maxdepth: 3
    :caption: Code documentation:

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -14,7 +14,7 @@ You can also install the latest development version from GitHub using:
 
 .. code-block:: bash
 
-	$ pip install git+https://github.com/machinevision-toolbox/bdsim.git
+	$ pip install git+https://github.com/petercorke/bdsim.git
 
 .. warning:: The GitHub version may be unstable and is not recommended for production use. It may contain bugs or incomplete features. Use it at your own risk.
 
@@ -50,7 +50,7 @@ including them in square brackets after the package name.
 
 .. code-block:: bash
 
-	$ pip install machinevision-toolbox-python[extra]
+	$ pip install bdsim[extra]
 
 
 The available extras are:
@@ -67,7 +67,9 @@ The available extras are:
 +--------------+-------------------------------------------+
 | ``bdedit``   | PySide6 graphic editor support            |
 +--------------+-------------------------------------------+
-| ``all``      | All of the above                          |
+| ``all``      | All of the optional runtime extras        |
+|              | (``bdedit`` + ``jupyter``) — not ``dev``  |
+|              | or ``docs``, which are developer-only     |
 +--------------+-------------------------------------------+
 
 For example, to install the jupyter support extras, you would run:

--- a/docs/source/internals.rst
+++ b/docs/source/internals.rst
@@ -7,10 +7,12 @@ intended to be stable and supported across versions. It includes the classes and
 that are used to build and simulate block diagrams.
 
 BlockDiagram class
--------------------
+===================
 
-This class describes a block diagram, a collection of blocks and wires that
-can be "executed" by :meth:`BDSim.run`.
+A collection of blocks and wires that can be "executed" by :meth:`BDSim.run`. See the wiki's
+`Connecting blocks <https://github.com/petercorke/bdsim/wiki/Connecting-blocks>`_ and `Blocks, wires
+and plugs <https://github.com/petercorke/bdsim/wiki/Blocks%2C-Wires-and-Plugs>`_ pages for how this
+fits together conceptually.
 
 .. autoclass:: bdsim.BlockDiagram
    :members: compile, connect, report_summary, report_lists, dotfile, showgraph
@@ -21,7 +23,10 @@ can be "executed" by :meth:`BDSim.run`.
 BDSim class
 -----------
 
-This class describes the run-time environment for executing a block diagram.
+The run-time environment for executing a block diagram. See the wiki's
+`Running <https://github.com/petercorke/bdsim/wiki/Running>`_ and `Runtime options
+<https://github.com/petercorke/bdsim/wiki/Runtime-options>`_ pages for CLI/code options and how to
+invoke it.
 
 .. autoclass:: bdsim.BDSim
    :members: blockdiagram, run, blocks, block_library, report, done
@@ -32,8 +37,10 @@ This class describes the run-time environment for executing a block diagram.
 BDStruct class
 ---------------
 
-This class is a struct-like container for storing simulation data.  It is
-returned by :meth:`BDSim.run` and contains the time vector, state history, and any watched variables.
+A struct-like container for storing simulation data, returned by :meth:`BDSim.run`. See the wiki's
+`Simulation results <https://github.com/petercorke/bdsim/wiki/Simulation-results>`_ page for the full
+layout — continuous vs. discrete/clocked state, watched signals, and the deprecated per-signal
+accessors — rather than duplicating that explanation here.
 
 .. autoclass:: bdsim.BDStruct
    :members:
@@ -52,34 +59,39 @@ classes and methods that are used internally by the library, and may not be stab
 supported across versions. It is intended for developers who want to understand or
 modify the internals of ``bdsim``.
 
-BDSim class
-=============
+BDSim, full listing
+=====================
 
-This class describes the run-time environment for executing a block diagram.
+Full member listing for ``BDSim``/``BDStruct`` — see their descriptions and wiki links under
+`Simulation-user API`_ above; this section differs only in showing every member, not the curated
+public subset.
 
 .. autoclass:: bdsim.BDSim
    :members:
    :undoc-members:
    :show-inheritance:
    :special-members: __init__
+   :no-index:
 
 .. autoclass:: bdsim.BDStruct
    :members:
    :undoc-members:
    :show-inheritance:
    :special-members: __init__
+   :no-index:
 
 
-BlockDiagram class
-====================
+BlockDiagram, full listing
+=============================
 
-This class describes a block diagram, a collection of blocks and wires that
-can be "executed".
+Full member listing for ``BlockDiagram`` — see its description and wiki links under
+`Simulation-user API`_ above.
 
 .. autoclass:: bdsim.BlockDiagram
    :members: compile, connect, report_summary, report_lists, dotfile, showgraph
    :undoc-members:
    :show-inheritance:
+   :no-index:
 
 Components
 ===========
@@ -152,6 +164,9 @@ Continuous-time block
 
 Discrete-time block
 """""""""""""""""""""
+
+See the wiki's `Time stepping <https://github.com/petercorke/bdsim/wiki/Time-stepping>`_ page for how
+``Clock``/``TimeQ`` drive the scheduled-event queue that also carries animation/movie frames.
 
 .. autoclass:: bdsim.SampledBlock
    :members:

--- a/docs/source/jupyter-notebooks.rst
+++ b/docs/source/jupyter-notebooks.rst
@@ -91,9 +91,11 @@ In the browser using Jupyter lite
 Jupyter lite is a version of Jupyter that runs entirely in the browser, without the need
 for a server.  The environment supports NumPy and Matplotlib all compiled for the web.
 It is a great option for quickly trying out the notebooks without
-installing anything on your local machine.  To use it, just click the "Launch in Jupyter
-Lite" button at the top of each notebook page, and it will open the notebook in a new
-browser tab running Jupyter lite.
+installing anything on your local machine.  To use it, click the "open" link in the
+JupyterLite column of the table below, and it will open that notebook in a new
+browser tab running Jupyter lite. You can also start from the `index page
+<https://petercorke.github.io/bdsim/lite/lab/index.html?path=notebooks/index.ipynb>`_,
+also linked from the badge at the top of the project's README.
 
 
 In the cloud using Google Colab
@@ -126,17 +128,17 @@ Provided notebooks
    :widths: 28, 16, 16, 40
 
    "Notebook", "|jupyterlite_image|", "|colab_image|", "Description"
-   "`Introduction <https://github.com/petercorke/bdsim/blob/main/docs/notebooks/getting-started.ipynb>`_", "`open <https://petercorke.github.io/bdsim/lite/lab/index.html?path=notebooks/getting-started.ipynb>`_", "`open <https://colab.research.google.com/github/petercorke/bdsim/blob/main/docs/notebooks/getting-started.ipynb>`_", "A quick introduction to the package."
-   "`Discrete & hybrid systems <https://github.com/petercorke/bdsim/blob/main/docs/notebooks/discrete-time%2Bhybrid.ipynb>`_", "`open <https://petercorke.github.io/bdsim/lite/lab/index.html?path=notebooks/discrete-time%2Bhybrid.ipynb>`_", "`open <https://colab.research.google.com/github/petercorke/bdsim/blob/main/docs/notebooks/discrete-time%2Bhybrid.ipynb>`_", "Simulating discrete-time and mixed discrete-/continuous-time systems."
-   "`Event-based systems <https://github.com/petercorke/bdsim/blob/main/docs/notebooks/bouncing-ball.ipynb>`_", "`open <https://petercorke.github.io/bdsim/lite/lab/index.html?path=notebooks/bouncing-ball.ipynb>`_", "`open <https://colab.research.google.com/github/petercorke/bdsim/blob/main/docs/notebooks/bouncing-ball.ipynb>`_", "The classic bouncing ball example."
-   "`Advanced topics <https://github.com/petercorke/bdsim/blob/main/docs/notebooks/advanced-topics.ipynb>`_", "`open <https://petercorke.github.io/bdsim/lite/lab/index.html?path=notebooks/advanced-topics.ipynb>`_", "`open <https://colab.research.google.com/github/petercorke/bdsim/blob/main/docs/notebooks/advanced-topics.ipynb>`_", "Advanced options: options, movies, animation, block loading."
+   "`Introduction <https://github.com/petercorke/bdsim/blob/main/docs/notebooks/getting-started.ipynb>`_", "`open <https://petercorke.github.io/bdsim/lite/lab/index.html?path=notebooks/getting-started.ipynb>`__", "`open <https://colab.research.google.com/github/petercorke/bdsim/blob/main/docs/notebooks/getting-started.ipynb>`__", "A quick introduction to the package."
+   "`Discrete & hybrid systems <https://github.com/petercorke/bdsim/blob/main/docs/notebooks/discrete-time%2Bhybrid.ipynb>`_", "`open <https://petercorke.github.io/bdsim/lite/lab/index.html?path=notebooks/discrete-time%2Bhybrid.ipynb>`__", "`open <https://colab.research.google.com/github/petercorke/bdsim/blob/main/docs/notebooks/discrete-time%2Bhybrid.ipynb>`__", "Simulating discrete-time and mixed discrete-/continuous-time systems."
+   "`Event-based systems <https://github.com/petercorke/bdsim/blob/main/docs/notebooks/bouncing-ball.ipynb>`_", "`open <https://petercorke.github.io/bdsim/lite/lab/index.html?path=notebooks/bouncing-ball.ipynb>`__", "`open <https://colab.research.google.com/github/petercorke/bdsim/blob/main/docs/notebooks/bouncing-ball.ipynb>`__", "The classic bouncing ball example."
+   "`Advanced topics <https://github.com/petercorke/bdsim/blob/main/docs/notebooks/advanced-topics.ipynb>`_", "`open <https://petercorke.github.io/bdsim/lite/lab/index.html?path=notebooks/advanced-topics.ipynb>`__", "`open <https://colab.research.google.com/github/petercorke/bdsim/blob/main/docs/notebooks/advanced-topics.ipynb>`__", "Advanced options: options, movies, animation, block loading."
 
 
 Obtaining the notebooks
 -----------------------
 
 If you want to run the notebooks locally, you will need to obtain them from the GitHub repository.  
-You can download all the notebooks `directly from the GitHub web interface as a zip file <https://github.com/petercorke/bdsim/releases/latest/download/bdsim_notebooks.zip>`_, and extract the notebooks from the zip file.
+You can download all the notebooks `directly from the GitHub web interface as a zip file <https://github.com/petercorke/bdsim/releases/latest/download/bdsim_notebooks.zip>`__, and extract the notebooks from the zip file.
 
 Alternatively, you can clone the repository
 
@@ -145,7 +147,7 @@ Alternatively, you can clone the repository
     git clone https://github.com/petercorke/bdsim.git
 
 The notebooks are located in the ``docs/notebooks`` folder.  
-You can also navigate to `that folder on GitHub <https://github.com/petercorke/bdsim/tree/main/docs/notebooks>`_ and download the notebooks individually.
+You can also navigate to `that folder on GitHub <https://github.com/petercorke/bdsim/tree/main/docs/notebooks>`__ and download the notebooks individually.
 
 
 
@@ -163,7 +165,7 @@ Examples
 to build and simulate block diagrams.  These are located in the ``examples`` folder.
 You can run these examples from the command line.
 
-You can download all the examples `directly from the GitHub web interface as a zip file <https://github.com/petercorke/bdsim/releases/latest/download/bdsim_examples.zip>`_, and extract the Python files from the zip file.
+You can download all the examples `directly from the GitHub web interface as a zip file <https://github.com/petercorke/bdsim/releases/latest/download/bdsim_examples.zip>`__, and extract the Python files from the zip file.
 
 Alternatively, you can clone the repository
 
@@ -172,4 +174,4 @@ Alternatively, you can clone the repository
     git clone https://github.com/petercorke/bdsim.git
 
 The examples are located in the ``examples`` folder.  
-You can also navigate to `that folder on GitHub <https://github.com/petercorke/bdsim/tree/main/examples>`_ and download the examples individually.
+You can also navigate to `that folder on GitHub <https://github.com/petercorke/bdsim/tree/main/examples>`__ and download the examples individually.

--- a/src/bdsim/run_sim.py
+++ b/src/bdsim/run_sim.py
@@ -560,40 +560,40 @@ class BDSim(Runner):
         If ``sysargs`` is True, process command line arguments and passed
         options.  Command line arguments have precedence.
 
-        =================================  ===============  =========  =====================================================
-        Command line switch                Argument         Default    Behaviour
-        =================================  ===============  =========  =====================================================
-        ``--graphics``, ``+g``             graphics         True       enable graphical display
-        ``--no-graphics``, ``-g``          graphics         True       disable graphical display
-        ``--animation``, ``+a``            animation        False      update graphics at each time step
-        ``--no-animation``, ``-a``         animation        False      don't update graphics at each time step
-        ``--hold``, ``+H``                 hold             True       hold graphics in done()
-        ``--no-hold``, ``-H``              hold             True       do not hold graphics in done()
-        ``--altscreen``, ``+A``            altscreen        True       display plots on second monitor
-        ``--no-altscreen``, ``-A``         altscreen        True       do not display plots on second monitor
-        ``--no-progress``                   progress         True       do not display simulation progress bar
-        ``--backend BE``, ``-b BE``        backend          None       matplotlib backend
-        ``--tiles SPEC``, ``-t SPEC``      tiles            None       arrange figure tiles as RxC or square/wide/tall
-        ``--shape WxH``                    shape            None       window size (default: matplotlib default)
-        ``--movies [DIR]``, ``-m [DIR]``   movies           None       record all graphics blocks to MP4 files in DIR (default: .), sampled at ``animation_rate``
-        ``--no-movies``                    movies           None       disable automatic movie recording
-        ``--blocks``                       blocks           False      display block list at startup
-        ``--debug F``, ``-d F``            debug            ``''``     debug flags: p/ropagate, s/tate, d/eriv, i/nteractive, g/raphics-diagnostics
-        ``--animation-rate R``             animation_rate   20.0       target update rate for animation/debugger (Hz)
-        ``--simtime T[,dt]``, ``-S``       simtime          None       simulation time as T or T,dt
-        ``--dt DT``                        dt               None       output sample interval (build solve_ivp t_eval)
-        ``--max-step DT``                  max_step         None       maximum solve_ivp integration step
-        ``--atol ATOL``                    atol             None       absolute tolerance for solve_ivp
-        ``--rtol RTOL``                    rtol             None       relative tolerance for solve_ivp
-        ``--method NAME``                  method           None       solve_ivp method (RK45, DOP853, Radau, BDF, LSODA)
-        ``--verbose``, ``-v``              verbose          False      be verbose
-        ``--quiet``, ``-q``               quiet            False      suppress reports and progress bar
-        ``-p [FILE]``, ``--pickle [FILE]`` outfile          None       output pickled results (default: bd.out)
-        ``-o [FILE]``, ``--out [FILE]``    outfile          None       *(deprecated, use -p/--pickle)*
-        ``-j [FILE]``, ``--json [FILE]``   jsonfile         None       output JSON results (default: bd.json)
-        ``--set P``, ``-s P``              setparam         ``[]``     override block parameter: ``block:param=value``
-        ``--global G``                     setglob          ``[]``     override global parameter: ``var=value``
-        =================================  ===============  =========  =====================================================
+        ==================================  ==============  =======  ==========================================================================================
+        Command line switch                 Argument        Default  Behaviour
+        ==================================  ==============  =======  ==========================================================================================
+        ``--graphics``, ``+g``              graphics        True     enable graphical display
+        ``--no-graphics``, ``-g``           graphics        True     disable graphical display
+        ``--animation``, ``+a``             animation       False    update graphics at each time step
+        ``--no-animation``, ``-a``          animation       False    don't update graphics at each time step
+        ``--hold``, ``+H``                  hold            True     hold graphics in done()
+        ``--no-hold``, ``-H``               hold            True     do not hold graphics in done()
+        ``--altscreen``, ``+A``             altscreen       True     display plots on second monitor
+        ``--no-altscreen``, ``-A``          altscreen       True     do not display plots on second monitor
+        ``--no-progress``                   progress        True     do not display simulation progress bar
+        ``--backend BE``, ``-b BE``         backend         None     matplotlib backend
+        ``--tiles SPEC``, ``-t SPEC``       tiles           None     arrange figure tiles as RxC or square/wide/tall
+        ``--shape WxH``                     shape           None     window size (default: matplotlib default)
+        ``--movies [DIR]``, ``-m [DIR]``    movies          None     record all graphics blocks to MP4 files in DIR (default: .), sampled at ``animation_rate``
+        ``--no-movies``                     movies          None     disable automatic movie recording
+        ``--blocks``                        blocks          False    display block list at startup
+        ``--debug F``, ``-d F``             debug           ``''``   debug flags: p/ropagate, s/tate, d/eriv, i/nteractive, g/raphics-diagnostics
+        ``--animation-rate R``              animation_rate  20.0     target update rate for animation/debugger (Hz)
+        ``--simtime T[,dt]``, ``-S``        simtime         None     simulation time as T or T,dt
+        ``--dt DT``                         dt              None     output sample interval (build solve_ivp t_eval)
+        ``--max-step DT``                   max_step        None     maximum solve_ivp integration step
+        ``--atol ATOL``                     atol            None     absolute tolerance for solve_ivp
+        ``--rtol RTOL``                     rtol            None     relative tolerance for solve_ivp
+        ``--method NAME``                   method          None     solve_ivp method (RK45, DOP853, Radau, BDF, LSODA)
+        ``--verbose``, ``-v``               verbose         False    be verbose
+        ``--quiet``, ``-q``                 quiet           False    suppress reports and progress bar
+        ``-p [FILE]``, ``--pickle [FILE]``  outfile         None     output pickled results (default: bd.out)
+        ``-o [FILE]``, ``--out [FILE]``     outfile         None     *(deprecated, use -p/--pickle)*
+        ``-j [FILE]``, ``--json [FILE]``    jsonfile        None     output JSON results (default: bd.json)
+        ``--set P``, ``-s P``               setparam        ``[]``   override block parameter: ``block:param=value``
+        ``--global G``                      setglob         ``[]``   override global parameter: ``var=value``
+        ==================================  ==============  =======  ==========================================================================================
 
         .. note:: ``animation`` and ``graphics`` options are coupled.  If
             ``graphics=False``, all graphics is suppressed.  If


### PR DESCRIPTION
## Summary

The wiki (recently overhauled — see the wiki's `wiki-review-2026-08.md` session notes) and the Sphinx
docs had drifted independently and barely referenced each other: a reader landing on either one had
no signal the other existed. This adds reciprocal pointers, and along the way fixes real bugs found
while verifying the Sphinx content against current code.

**Cross-referencing:**
- Wiki `Home.md`/sidebar now link to the Sphinx API reference (done directly on the wiki, not part of
  this PR's diff)
- `index.rst` now links to the wiki near the top, not just buried in `bdsim.rst`
- `bdsim.rst`'s wiki-links list expanded to include the wiki's new pages (Simulation results,
  Animation and movies, Time stepping)
- `internals.rst` now points at wiki pages (`Simulation-results`, `Running`, `Runtime-options`,
  `Connecting-blocks`, `Blocks,-Wires-and-Plugs`, `Time-stepping`) instead of re-explaining concepts
  inline
- Repo homepage field set to `https://petercorke.github.io/bdsim/` (was empty)

**Bugs found and fixed while verifying:**
- `bdsim.rst`: stale `sim.blocks()` listing (same drift already fixed on the wiki), an unexplained
  `movie=` dependency baked into the first tutorial example, two stale bullets describing removed
  code, fabricated `watch=` example output replaced with real verified output, deprecated
  `bd.report()` call
- `installation.rst`: `pip install` commands pointing at the wrong GitHub org and an entirely
  different package (copy-pasted from MVTB's docs template)
- `jupyter-notebooks.rst`: a "Launch in JupyterLite" button that doesn't actually exist in the
  notebooks or the build, 8 RST duplicate-target warnings
- `internals.rst`: `BDSim`/`BDStruct`/`BlockDiagram` were fully autodoc'd twice (Simulation-user API
  and Developer API sections), registering the same Sphinx objects twice — real
  `duplicate-object-description` build warnings, not just conceptual duplication — plus a
  heading-level-inconsistency bug found in the same spot
- `bdsim.blocks.rst`: dead `bdedit` link (pre-`src/`-layout path, `master` branch that doesn't exist)
- `src/bdsim/run_sim.py`: malformed RST table in `BDSim.__init__`'s docstring that was silently
  breaking the CLI options table in the actual rendered API docs
- `getting-started.ipynb`: one deprecated `bd.report()` call

Verified by building the docs locally before and after: went from a real "Malformed table" error plus
~15 duplicate-object/title-level/duplicate-target warnings down to zero, excluding 22 pre-existing,
unrelated `sphinx_autodoc_typehints` warnings on operator dunder methods — tracked separately as #78
rather than fixed here, since that touches `Block`/`Plug` operator-overload source, not docs.

## Test plan

- [x] `sphinx-build -b html docs/source <out>` — before: 1 ERROR + ~15 relevant WARNINGs; after: 0
      (excluding the 22 pre-existing `local_function` warnings tracked in #78)
- [x] Spot-checked rendered HTML output for `internals.html` and `bdsim.html` to confirm no
      duplicate-content markers and the corrected block listing render correctly
- [x] All wiki-facing links point at pages that exist on the wiki as of this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)